### PR TITLE
SOAP MTOM attachment support

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/xml/schema/JarWSDLLocator.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/xml/schema/JarWSDLLocator.java
@@ -1,0 +1,70 @@
+package com.consol.citrus.xml.schema;
+
+import java.io.IOException;
+import java.net.URI;
+import javax.wsdl.xml.WSDLLocator;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.xml.sax.InputSource;
+
+/**
+ * Locates WSDL import sources in Jar files
+ */
+public class JarWSDLLocator implements WSDLLocator {
+
+    private Resource wsdl;
+    private Resource importResource = null;
+
+    public JarWSDLLocator(Resource wsdl) {
+        this.wsdl = wsdl;
+    }
+    
+    @Override
+    public InputSource getBaseInputSource() {
+        try {
+            return new InputSource(wsdl.getInputStream());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public InputSource getImportInputSource(String parentLocation, String importLocation) {
+        String resolvedImportLocation;
+        URI importURI = URI.create(importLocation);
+        if (importURI.isAbsolute()) {
+            resolvedImportLocation = importLocation;
+        } else {
+            resolvedImportLocation = parentLocation.substring(0, parentLocation.lastIndexOf("/") + 1) + importLocation;
+        }
+        
+        try {
+            importResource = new PathMatchingResourcePatternResolver().getResource(resolvedImportLocation);
+            return new InputSource(importResource.getInputStream());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getBaseURI() {
+        try {
+            return wsdl.getURI().toString();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getLatestImportURI() {
+        try {
+            return importResource.getURI().toString();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/modules/citrus-core/src/main/java/com/consol/citrus/xml/schema/WsdlXsdSchema.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/xml/schema/WsdlXsdSchema.java
@@ -135,6 +135,7 @@ public class WsdlXsdSchema extends SimpleXsdSchema implements InitializingBean {
                 TransformerFactory.newInstance().newTransformer().transform(source, result);
                 Resource schemaResource = new ByteArrayResource(bos.toByteArray());
                 
+                importedSchemas.put(schema.getElement().getAttribute("targetNamespace"), null);
                 addImportedSchemas(schema, importedSchemas);
                 schemas.add(schemaResource);
                 schemaSources.add(source);

--- a/modules/citrus-integration/src/citrus/java/com/consol/citrus/ws/SendSoapMessageWithAttachmentITest.java
+++ b/modules/citrus-integration/src/citrus/java/com/consol/citrus/ws/SendSoapMessageWithAttachmentITest.java
@@ -28,4 +28,8 @@ public class SendSoapMessageWithAttachmentITest extends AbstractTestNGCitrusTest
     @Test
     @CitrusXmlTest
     public void SendSoapMessageWithAttachmentITest() {}
+    
+    @Test
+    @CitrusXmlTest
+    public void SendSoapMessageWithMtomAttachmentITest() {}    
 }

--- a/modules/citrus-integration/src/citrus/resources/citrus-context.xml
+++ b/modules/citrus-integration/src/citrus/resources/citrus-context.xml
@@ -86,7 +86,17 @@
     <citrus-ws:client id="webServiceClient"
          request-url="http://localhost:8071"
          message-factory="messageFactory"/>
-                              
+
+    <!-- SOAP test client -->
+    <citrus-ws:client id="SampleSoapClient"
+                      request-url="http://localhost:8091"/>
+
+    <!-- SOAP test server -->
+    <citrus-ws:server id="SampleSoapServer"
+                      port="8091" 
+                      auto-start="true"
+                      resource-base="src/citrus/resources"/>    
+    
     <citrus-jms:endpoint id="webServiceRequestReceiver"
                              destination-name="${jms.ws.stub.request}"/>
     

--- a/modules/citrus-integration/src/citrus/resources/citrus-schemas-context.xml
+++ b/modules/citrus-integration/src/citrus/resources/citrus-schemas-context.xml
@@ -26,5 +26,13 @@
       <citrus:ref schema="helloSchemaExtended" />
     </citrus:schemas>
   </citrus:schema-repository>
+  
+  <citrus:schema id="bookStoreSchemaExtended" location="classpath:com/consol/citrus/demo/BookStoreExtened.wsdl" />
+  
+  <citrus:schema-repository id="bookStoreSchemaRepository">
+    <citrus:schemas>
+      <citrus:ref schema="bookStoreSchemaExtended" />
+    </citrus:schemas>
+  </citrus:schema-repository>
 
 </beans>

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/ws/soapIcon.txt
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/ws/soapIcon.txt
@@ -1,0 +1,2 @@
+This is a binary icon attachment!
+Variables %{test} should not be replaced!

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/ws/soapImage.txt
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/ws/soapImage.txt
@@ -1,0 +1,2 @@
+This is a binary image attachment!
+Variables %{test} should not be replaced!

--- a/modules/citrus-integration/src/citrus/tests/com/consol/citrus/ws/SendSoapMessageWithMtomAttachmentITest.xml
+++ b/modules/citrus-integration/src/citrus/tests/com/consol/citrus/ws/SendSoapMessageWithMtomAttachmentITest.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase" 
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:ws="http://www.citrusframework.org/schema/ws/testcase" 
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+                                  http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd
+                                  http://www.citrusframework.org/schema/ws/testcase http://www.citrusframework.org/schema/ws/testcase/citrus-ws-testcase.xsd">
+    <testcase name="SendSoapMessageWithMtomAttachmentITest">
+        <meta-info>
+            <author>Reinhard Steiner</author>
+            <creationdate>2015-01-12</creationdate>
+            <status>FINAL</status>
+        </meta-info>
+        
+        <description>Sending SOAP messages with mtom attachments</description>
+        
+        <variables>
+            <variable name="test" value="This string should not be inserted into binary SOAP attachments"/>
+            <variable name="imageFile" value="classpath:com/consol/citrus/ws/soapImage.txt"/>
+            <variable name="iconFile" value="classpath:com/consol/citrus/ws/soapIcon.txt"/>
+        </variables>
+        
+        <actions>
+            
+            <!-- Test sending one mtom attachment -->
+            <parallel>
+            	<ws:send endpoint="SampleSoapClient" schema-repository="bookStoreSchemaRepository" mtom-enabled="true">
+                    <message>
+                        <data>
+                            <![CDATA[
+                                <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                    <isbn>1234</isbn>
+                                    <image>cid:IMAGE</image>
+                                    <icon></icon>
+                                </bookStore:addBookImage>
+                            ]]>
+                        </data>
+                    </message>
+                    <ws:attachment content-id="IMAGE" content-type="application/octet-stream">
+                        <ws:resource file="${imageFile}"/>
+                    </ws:attachment>
+                </ws:send>
+                                
+                <sequential>
+                    <ws:receive endpoint="SampleSoapServer">
+                        <message schema-validation="false" schema-repository="bookStoreSchemaRepository">
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <isbn>1234</isbn>
+                                        <image><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:IMAGE"/></image>
+                                        <icon></icon>
+                                    </bookStore:addBookImage>
+                                ]]>
+                            </data>
+                        </message>
+                        <ws:attachment content-id="IMAGE" content-type="application/octet-stream">
+                            <ws:resource file="${imageFile}"/>
+                        </ws:attachment>
+                    </ws:receive>
+                    
+                    <ws:send endpoint="SampleSoapServer" schema-repository="bookStoreSchemaRepository">
+                        <message>
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <success>true</success>
+                                    </bookStore:addBookImageResponse>
+                                ]]>
+                            </data>
+                        </message>
+                    </ws:send>
+                </sequential>
+            </parallel>
+            
+            <ws:receive endpoint="SampleSoapClient">
+                <message schema-validation="true" schema-repository="bookStoreSchemaRepository">
+                    <data>
+                        <![CDATA[
+                            <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                <success>true</success>
+                            </bookStore:addBookImageResponse>
+                        ]]>
+                    </data>
+                </message>
+            </ws:receive>
+                        
+            
+            <!-- Test sending two mtom attachments -->
+            <parallel>
+            	<ws:send endpoint="SampleSoapClient" schema-repository="bookStoreSchemaRepository" mtom-enabled="true">
+                    <message>
+                        <data>
+                            <![CDATA[
+                                <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                    <isbn>1234</isbn>
+                                    <image>cid:IMAGE</image>
+                                    <icon>cid:ICON</icon>
+                                </bookStore:addBookImage>
+                            ]]>
+                        </data>
+                    </message>
+                    <ws:attachment content-id="IMAGE" content-type="application/octet-stream">
+                        <ws:resource file="${imageFile}"/>
+                    </ws:attachment>
+                    <ws:attachment content-id="ICON" content-type="application/octet-stream">
+                        <ws:resource file="${iconFile}"/>
+                    </ws:attachment>
+                </ws:send>
+                                
+                <sequential>
+                    <ws:receive endpoint="SampleSoapServer">
+                        <message schema-validation="false" schema-repository="bookStoreSchemaRepository">
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <isbn>1234</isbn>
+                                        <image><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:IMAGE"/></image>
+                                        <icon><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:ICON"/></icon>
+                                    </bookStore:addBookImage>
+                                ]]>
+                            </data>
+                        </message>
+                        <ws:attachment content-id="IMAGE" content-type="application/octet-stream">
+                            <ws:resource file="${imageFile}"/>
+                        </ws:attachment>
+                        <ws:attachment content-id="ICON" content-type="application/octet-stream">
+                            <ws:resource file="${iconFile}"/>
+                        </ws:attachment>
+                    </ws:receive>
+                    
+                    <ws:send endpoint="SampleSoapServer" schema-repository="bookStoreSchemaRepository">
+                        <message>
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <success>true</success>
+                                    </bookStore:addBookImageResponse>
+                                ]]>
+                            </data>
+                        </message>
+                    </ws:send>
+                </sequential>
+            </parallel>
+            
+            <ws:receive endpoint="SampleSoapClient">
+                <message schema-validation="true" schema-repository="bookStoreSchemaRepository">
+                    <data>
+                        <![CDATA[
+                            <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                <success>true</success>
+                            </bookStore:addBookImageResponse>
+                        ]]>
+                    </data>
+                </message>
+            </ws:receive>
+            
+            
+            <!-- Test sending two mtom inline attachments -->
+            <parallel>
+            	<ws:send endpoint="SampleSoapClient" schema-repository="bookStoreSchemaRepository" mtom-enabled="true">
+                    <message>
+                        <data>
+                            <![CDATA[
+                                <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                    <isbn>1234</isbn>
+                                    <image>cid:IMAGE</image>
+                                    <icon>cid:ICON</icon>
+                                </bookStore:addBookImage>
+                            ]]>
+                        </data>
+                    </message>
+                    <ws:attachment content-id="IMAGE" content-type="application/octet-stream" mtom-inline="true">
+                        <ws:resource file="${imageFile}"/>
+                    </ws:attachment>
+                    <ws:attachment content-id="ICON" content-type="application/octet-stream" mtom-inline="true">
+                        <ws:resource file="${iconFile}"/>
+                    </ws:attachment>
+                </ws:send>
+                
+                <sequential>
+                    <ws:receive endpoint="SampleSoapServer">
+                        <message schema-validation="true" schema-repository="bookStoreSchemaRepository">
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImage xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <isbn>1234</isbn>
+                                        <image>VGhpcyBpcyBhIGJpbmFyeSBpbWFnZSBhdHRhY2htZW50IQ0KVmFyaWFibGVzICV7dGVzdH0gc2hvdWxkIG5vdCBiZSByZXBsYWNlZCE=</image>
+                                        <icon>5468697320697320612062696E6172792069636F6E206174746163686D656E74210D0A5661726961626C657320257B746573747D2073686F756C64206E6F74206265207265706C6163656421</icon>
+                                    </bookStore:addBookImage>
+                                ]]>
+                            </data>
+                        </message>
+                    </ws:receive>
+                    
+                    <ws:send endpoint="SampleSoapServer" schema-repository="bookStoreSchemaRepository">
+                        <message>
+                            <data>
+                                <![CDATA[
+                                    <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                        <success>true</success>
+                                    </bookStore:addBookImageResponse>
+                                ]]>
+                            </data>
+                        </message>
+                    </ws:send>
+                </sequential>
+            </parallel>
+            
+            <ws:receive endpoint="SampleSoapClient">
+                <message schema-validation="true" schema-repository="bookStoreSchemaRepository">
+                    <data>
+                        <![CDATA[
+                            <bookStore:addBookImageResponse xmlns:bookStore="http://www.citrusframework.org/bookstore/">
+                                <success>true</success>
+                            </bookStore:addBookImageResponse>
+                        ]]>
+                    </data>
+                </message>
+            </ws:receive>
+        </actions>
+    </testcase>
+</spring:beans>

--- a/modules/citrus-integration/src/main/resources/com/consol/citrus/demo/BookStoreExtened.wsdl
+++ b/modules/citrus-integration/src/main/resources/com/consol/citrus/demo/BookStoreExtened.wsdl
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://www.citrusframework.org/bookstore/" xmlns:book="http://www.citrusframework.org/book/wsdl" xmlns:audio="http://www.citrusframework.org/bookstore/audio" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" name="BookStore" targetNamespace="http://www.citrusframework.org/bookstore/">
+    <wsdl:types>
+        <xsd:schema xmlns="http://www.citrusframework.org/bookstore/" xmlns:book="http://www.citrusframework.org/book" xmlns:author="http://www.citrusframework.org/author" targetNamespace="http://www.citrusframework.org/bookstore/">
+            <xsd:element name="addBook" type="tns:BookType"/>
+            <xsd:element name="addBookResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="success" type="xsd:boolean"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="deleteBook">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="isbn" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="deleteBookResponse" type="tns:BaseResponseType"/>
+
+            <xsd:complexType name="BookType">
+                <xsd:sequence>
+                    <xsd:element name="author" type="xsd:string"/>
+                    <xsd:element name="title" type="xsd:string"/>
+                    <xsd:element name="isbn" type="xsd:string"/>
+                    <xsd:element name="year" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="BaseResponseType">
+                <xsd:sequence>
+                    <xsd:element name="success" type="xsd:boolean"/>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:element name="addBookImage">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="isbn" type="xsd:string"/>
+                        <xsd:element name="image" type="xsd:base64Binary" xmime:expectedContentTypes="application/octet-stream"/>
+                        <xsd:element name="icon" type="xsd:hexBinary" xmime:expectedContentTypes="application/octet-stream"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="addBookImageResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="success" type="xsd:boolean"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+
+        <xsd:schema targetNamespace="http://www.citrusframework.org/bookstore/audio">
+            <xsd:import namespace="http://www.citrusframework.org/bookstore/"/>
+
+            <xsd:element name="addBookAudio" type="audio:AudioBookType"/>
+
+            <xsd:element name="addBookAudioResponse" type="tns:BaseResponseType"/>
+
+            <xsd:complexType name="AudioBookType">
+                <xsd:complexContent>
+                    <xsd:extension base="tns:BookType">
+                        <xsd:sequence>
+                            <xsd:element name="length" type="xsd:integer"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="addBook">
+        <wsdl:part element="tns:addBook" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="addBookResponse">
+        <wsdl:part element="tns:addBookResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="addBookAudio">
+        <wsdl:part element="audio:addBookAudio" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="addBookAudioResponse">
+        <wsdl:part element="audio:addBookAudioResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="deleteBookRequest">
+        <wsdl:part element="tns:deleteBook" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="deleteBookResponse">
+        <wsdl:part element="tns:deleteBookResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="addBookImage">
+        <wsdl:part element="tns:addBookImage" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="addBookImageResponse">
+        <wsdl:part element="tns:addBookImageResponse" name="parameters"/>
+    </wsdl:message>
+
+    <wsdl:portType name="BookStore">
+        <wsdl:operation name="addBook">
+            <wsdl:input message="tns:addBook"/>
+            <wsdl:output message="tns:addBookResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="addBookAudio">
+            <wsdl:input message="tns:addBookAudio"/>
+            <wsdl:output message="tns:addBookAudioResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteBook">
+            <wsdl:input message="tns:deleteBookRequest"/>
+            <wsdl:output message="tns:deleteBookResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="addBookImage">
+            <wsdl:input message="tns:addBookImage"/>
+            <wsdl:output message="tns:addBookImageResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="BookStoreSOAP" type="tns:BookStore">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="addBook">
+            <soap:operation soapAction="http://www.citrusframework.org/bookstore/addBook"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addBookAudio">
+            <soap:operation soapAction="http://www.citrusframework.org/bookstore/addBookAudio"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="deleteBook">
+            <soap:operation soapAction="http://www.citrusframework.org/bookstore/deleteBook"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addBookImage">
+            <soap:operation soapAction="http://www.citrusframework.org/bookstore/addBookImage"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="BookStore">
+        <wsdl:port binding="tns:BookStoreSOAP" name="BookStoreSOAP">
+            <soap:address location="http://www.citrusframework.org/bookstore/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase-2.0.1.xsd
+++ b/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase-2.0.1.xsd
@@ -72,6 +72,7 @@
                     <xs:element name="attachment" type="SoapAttachmentType" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
                 <xs:attribute name="mtom-enabled"/>
+                <xs:attribute name="schema-repository"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase-2.0.1.xsd
+++ b/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase-2.0.1.xsd
@@ -36,6 +36,7 @@
         <xs:attribute name="content-id"/>
         <xs:attribute name="content-type"/>
         <xs:attribute name="charset-name"/>
+        <xs:attribute name="mtom-inline"/>
     </xs:complexType>
 
     <xs:complexType name="SoapAssertActionType">
@@ -70,6 +71,7 @@
                 <xs:sequence>
                     <xs:element name="attachment" type="SoapAttachmentType" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="mtom-enabled"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase.xsd
+++ b/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase.xsd
@@ -72,6 +72,7 @@
                     <xs:element name="attachment" type="SoapAttachmentType" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
                 <xs:attribute name="mtom-enabled"/>
+                <xs:attribute name="schema-repository"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase.xsd
+++ b/modules/citrus-model/model-ws/src/main/resources/com/consol/citrus/schema/citrus-ws-testcase.xsd
@@ -36,6 +36,7 @@
         <xs:attribute name="content-id"/>
         <xs:attribute name="content-type"/>
         <xs:attribute name="charset-name"/>
+        <xs:attribute name="mtom-inline"/>
     </xs:complexType>
 
     <xs:complexType name="SoapAssertActionType">
@@ -70,6 +71,7 @@
                 <xs:sequence>
                     <xs:element name="attachment" type="SoapAttachmentType" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="mtom-enabled"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/modules/citrus-ws/pom.xml
+++ b/modules/citrus-ws/pom.xml
@@ -56,6 +56,15 @@
         <artifactId>jetty-servlet</artifactId>
     </dependency>
     
+    <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+    </dependency>
+    
     <!-- Spring Framework -->
     <dependency>
         <groupId>org.springframework</groupId>

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/ReceiveSoapMessageAction.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/ReceiveSoapMessageAction.java
@@ -75,9 +75,11 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction {
                 if (StringUtils.hasText(attachment.getContent())) {
                     attachment.setContent(context.replaceDynamicContentInString(attachment.getContent()));
                 } else if (attachment.getContentResourcePath() != null) {
-                    attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
+                    if (attachment.getContentType().startsWith("text/"))
+                        attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
+                    else
+                        attachment.setContentResourcePath(context.replaceDynamicContentInString(attachment.getContentResourcePath()));
                 }
-
             }
 
             if (!attachments.isEmpty()) {

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/ReceiveSoapMessageAction.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/ReceiveSoapMessageAction.java
@@ -62,24 +62,7 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction {
             }
 
             for (SoapAttachment attachment : attachments) {
-                // handle variables in content id
-                if (attachment.getContentId() != null) {
-                    attachment.setContentId(context.replaceDynamicContentInString(attachment.getContentId()));
-                }
-
-                // handle variables in content type
-                if (attachment.getContentType() != null) {
-                    attachment.setContentType(context.replaceDynamicContentInString(attachment.getContentType()));
-                }
-
-                if (StringUtils.hasText(attachment.getContent())) {
-                    attachment.setContent(context.replaceDynamicContentInString(attachment.getContent()));
-                } else if (attachment.getContentResourcePath() != null) {
-                    if (attachment.getContentType().startsWith("text/"))
-                        attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
-                    else
-                        attachment.setContentResourcePath(context.replaceDynamicContentInString(attachment.getContentResourcePath()));
-                }
+                attachment.resolveDynamicContent(context);
             }
 
             if (!attachments.isEmpty()) {

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
@@ -72,7 +72,7 @@ public class SendSoapMessageAction extends SendMessageAction {
     private Boolean mtomEnabled = false;
     
     /** Explicit schema repository to use for this validation */
-    private String schemaRepository;
+    private String schemaRepository = "schemaRepository";
     
     @Override
     protected SoapMessage createMessage(TestContext context, String messageType) {

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
@@ -21,13 +21,40 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.message.Message;
 import com.consol.citrus.util.FileUtils;
+import com.consol.citrus.util.XMLUtils;
 import com.consol.citrus.ws.message.SoapAttachment;
 import com.consol.citrus.ws.message.SoapMessage;
+import com.consol.citrus.xml.XsdSchemaRepository;
+import com.consol.citrus.xml.schema.TargetNamespaceSchemaMappingStrategy;
+import com.consol.citrus.xml.schema.WsdlXsdSchema;
+import com.consol.citrus.xml.schema.XsdSchemaMappingStrategy;
 import org.springframework.util.StringUtils;
-
+import org.springframework.xml.xsd.XsdSchema;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 
 /**
  * Message send action able to add SOAP attachment support to normal message sending action.
@@ -36,28 +63,71 @@ import java.util.List;
  */
 public class SendSoapMessageAction extends SendMessageAction {
 
+    private static Logger log = LoggerFactory.getLogger(SendSoapMessageAction.class);
+    
     /** SOAP attachment */
     private List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
 
+    /** enable/disable mtom attachments */
+    private Boolean mtomEnabled = false;
+    
     @Override
     protected SoapMessage createMessage(TestContext context, String messageType) {
         Message message = super.createMessage(context, getMessageType());
-
-        final SoapMessage soapMessage = new SoapMessage(message);
+        List<SoapAttachment> soapAttachments = new ArrayList<SoapAttachment>();
 
         try {
-            for (SoapAttachment attachment : attachments) {
-                if (StringUtils.hasText(attachment.getContent())) {
-                    attachment.setContent(context.replaceDynamicContentInString(attachment.getContent()));
-                } else if (attachment.getContentResourcePath() != null) {
-                    attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
-                }
+            if (!attachments.isEmpty()) {
+                String messagePayload = message.getPayload().toString();
+                
+                for (SoapAttachment attachment : attachments) {
+                    if (StringUtils.hasText(attachment.getContent())) {
+                        attachment.setContent(context.replaceDynamicContentInString(attachment.getContent()));
+                    } else if (attachment.getContentResourcePath() != null) {
+                        if (attachment.getContentType().startsWith("text/"))
+                            attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
+                        else
+                            attachment.setContentResourcePath(context.replaceDynamicContentInString(attachment.getContentResourcePath()));
+                    }
 
-                soapMessage.addAttachment(attachment);
+                    if (mtomEnabled) {
+                        String cid = "cid:" + attachment.getContentId();
+
+                        if (attachment.getMtomInline()) {
+                            if (messagePayload.contains(cid) && attachment.getInputStream().available() > 0) {
+                                String xsiType = getAttachmentXsiType(context, messagePayload, cid);
+
+                                if (xsiType.equals("base64binary")) {
+                                    messagePayload = messagePayload.replaceAll(cid, Base64.encodeBase64String(IOUtils.toByteArray(attachment.getInputStream())));
+                                } else if (xsiType.equals("hexBinary")) {
+                                    messagePayload = messagePayload.replaceAll(cid, Hex.encodeHexString(IOUtils.toByteArray(attachment.getInputStream())));
+                                } else {
+                                    throw new CitrusRuntimeException("Unsupported xsiType<" + xsiType + "> for attachment " + cid);
+                                }
+                                attachment = null;
+                            }
+                        } else {
+                            messagePayload = messagePayload.replaceAll(cid, "<xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\" href=\"" + cid + "\"/>");
+                            soapAttachments.add(attachment);
+                        }
+                    } else {
+                        soapAttachments.add(attachment);
+                    }
+                }
+                
+                if (mtomEnabled)
+                    message.setPayload(messagePayload);
             }
 
         } catch (IOException e) {
             throw new CitrusRuntimeException(e);
+        }
+
+        final SoapMessage soapMessage = new SoapMessage(message);
+        soapMessage.setMtomEnabled(mtomEnabled);
+        
+        for (SoapAttachment attachment : soapAttachments) {
+            soapMessage.addAttachment(attachment);
         }
 
         return soapMessage;
@@ -77,5 +147,71 @@ public class SendSoapMessageAction extends SendMessageAction {
      */
     public void setAttachments(List<SoapAttachment> attachments) {
         this.attachments = attachments;
+    }
+    
+    /**
+     * Enable or disable mtom attachments
+     * @param mtomEnabled
+     */
+    public void setMtomEnabled(Boolean enable) {
+        this.mtomEnabled = enable;
+    }
+
+    /**
+     * Gets mtom attachments enabled
+     * @return 
+     */
+    public Boolean getMtomEnabled() {
+        return this.mtomEnabled;
+    }
+
+    /**
+     * Get data type from XML node. Supported data types are "base64binary" and "hexBinary"
+     * @param context
+     * @param xmlMessage
+     * @param cid
+     * @return 
+     */
+    private String getAttachmentXsiType(TestContext context, String xmlMessage, String cid) {
+        String xsiType = "base64binary";
+        XsdSchemaRepository schemaRepository = context.getApplicationContext().getBean("schemaRepository", XsdSchemaRepository.class);
+        if (schemaRepository != null) {
+            XsdSchemaMappingStrategy schemaMappingStrategy = new TargetNamespaceSchemaMappingStrategy();
+            XsdSchema schema = schemaMappingStrategy.getSchema(
+                    schemaRepository.getSchemas(), XMLUtils.parseMessagePayload(xmlMessage));
+            if (schema == null) {
+                log.error("No matching schema found to parse the attachment xml element for cid: " + cid);
+            } else {
+                try {
+                    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                    dbf.setNamespaceAware(true);
+                    dbf.setValidating(false);
+
+                    if (schema instanceof WsdlXsdSchema) {
+                        dbf.setSchema(((WsdlXsdSchema)schema).getCombinedSchema());
+                    } else {
+                        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                        dbf.setSchema(sf.newSchema(schema.getSource()));
+                    }
+
+                    DocumentBuilder db = dbf.newDocumentBuilder();
+                    Document doc = db.parse(new InputSource(new StringReader(xmlMessage)));
+                    doc.getDocumentElement().normalize();
+
+                    XPath xPath = XPathFactory.newInstance().newXPath();
+                    String expression = "//*[contains(normalize-space(text()), '" + cid + "')]";
+                    Node node = (Node) xPath.compile(expression).evaluate(doc, XPathConstants.NODE);
+                    if (node instanceof Element) {
+                        xsiType = ((Element) node).getSchemaTypeInfo().getTypeName();
+                    } else {
+                        log.warn("parent element of cid: " + cid + " not found in xml payload.");
+                    }
+                } catch (SAXException | ParserConfigurationException | IOException | XPathExpressionException e) {
+                    log.warn(e.getLocalizedMessage(), e);
+                }
+            }
+        }
+
+        return xsiType;
     }
 }

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/actions/SendSoapMessageAction.java
@@ -84,24 +84,7 @@ public class SendSoapMessageAction extends SendMessageAction {
                 String messagePayload = message.getPayload().toString();
                 
                 for (SoapAttachment attachment : attachments) {
-                    // handle variables in content id
-                    if (attachment.getContentId() != null) {
-                        attachment.setContentId(context.replaceDynamicContentInString(attachment.getContentId()));
-                    }
-
-                    // handle variables in content type
-                    if (attachment.getContentType() != null) {
-                        attachment.setContentType(context.replaceDynamicContentInString(attachment.getContentType()));
-                    }
-
-                    if (StringUtils.hasText(attachment.getContent())) {
-                        attachment.setContent(context.replaceDynamicContentInString(attachment.getContent()));
-                    } else if (attachment.getContentResourcePath() != null) {
-                        if (attachment.getContentType().startsWith("text/"))
-                            attachment.setContent(context.replaceDynamicContentInString(FileUtils.readToString(FileUtils.getFileResource(attachment.getContentResourcePath(), context))));
-                        else
-                            attachment.setContentResourcePath(context.replaceDynamicContentInString(attachment.getContentResourcePath()));
-                    }
+                    attachment.resolveDynamicContent(context);
 
                     if (mtomEnabled) {
                         String cid = "cid:" + attachment.getContentId();

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SendSoapMessageActionParser.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SendSoapMessageActionParser.java
@@ -45,6 +45,10 @@ public class SendSoapMessageActionParser extends SendMessageActionParser {
         }
 
         builder.addPropertyValue("attachments", attachments);
+        
+        if (element.hasAttribute("mtom-enabled")) {
+            builder.addPropertyValue("mtomEnabled", element.getAttribute("mtom-enabled"));
+        }
 
         return builder;
     }

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SendSoapMessageActionParser.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SendSoapMessageActionParser.java
@@ -50,6 +50,10 @@ public class SendSoapMessageActionParser extends SendMessageActionParser {
             builder.addPropertyValue("mtomEnabled", element.getAttribute("mtom-enabled"));
         }
 
+        if (element.hasAttribute("schema-repository")) {
+            builder.addPropertyValue("schemaRepository", element.getAttribute("schema-repository"));
+        }
+        
         return builder;
     }
 

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SoapAttachmentParser.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/config/xml/SoapAttachmentParser.java
@@ -52,6 +52,10 @@ public final class SoapAttachmentParser {
             soapAttachment.setCharsetName(attachmentElement.getAttribute("charset-name"));
         }
 
+        if (attachmentElement.hasAttribute("mtom-inline")) {
+            soapAttachment.setMtomInline(Boolean.parseBoolean(attachmentElement.getAttribute("mtom-inline")));
+        }
+        
         Element attachmentDataElement = DomUtils.getChildElementByTagName(attachmentElement, "data");
         if (attachmentDataElement != null) {
             soapAttachment.setContent(DomUtils.getTextValue(attachmentDataElement));

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/SoapMessage.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/SoapMessage.java
@@ -36,6 +36,9 @@ public class SoapMessage extends DefaultMessage {
     /** Optional list of SOAP attachments */
     private List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
 
+    /** enable/disable mtom attachments */
+    private Boolean mtomEnabled = false;
+    
     /**
      * Constructs copy of given message.
      * @param message
@@ -110,5 +113,21 @@ public class SoapMessage extends DefaultMessage {
      */
     public List<SoapAttachment> getAttachments() {
         return attachments;
+    }
+    
+    /**
+     * Enable or disable mtom attachments
+     * @param mtomEnabled
+     */
+    public void setMtomEnabled(Boolean enable) {
+        this.mtomEnabled = enable;
+    }
+
+    /**
+     * Gets mtom attachments enabled
+     * @return 
+     */
+    public Boolean getMtomEnabled() {
+        return this.mtomEnabled;
     }
 }

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
@@ -62,7 +62,7 @@ import java.util.Map.Entry;
 public class SoapMessageConverter implements WebServiceMessageConverter {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(SoapResponseMessageCallback.class);
+    private static Logger log = LoggerFactory.getLogger(SoapMessageConverter.class);
     
     /** Should keep soap envelope when creating internal message */
     private boolean keepSoapEnvelope = false;
@@ -131,15 +131,17 @@ public class SoapMessageConverter implements WebServiceMessageConverter {
             }
         }
 
+        boolean convertedToXOP = false;
         for (final Attachment attachment : soapMessage.getAttachments()) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Adding attachment to SOAP message: '%s' ('%s')", attachment.getContentId(), attachment.getContentType()));
             }
 
-            if (soapMessage.getMtomEnabled()) {
+            if (soapMessage.getMtomEnabled() && !convertedToXOP) {
                 if (soapRequest instanceof SaajSoapMessage) {
                     log.debug("Converting SaajSoapMessage to XOP package");
                     ((SaajSoapMessage) soapRequest).convertToXopPackage();
+                    convertedToXOP = true;
                 } else if (soapRequest instanceof AxiomSoapMessage) {
                     log.warn("AxiomSoapMessage cannot be converted to XOP package");
                 }

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
@@ -136,6 +136,15 @@ public class SoapMessageConverter implements WebServiceMessageConverter {
                 log.debug(String.format("Adding attachment to SOAP message: '%s' ('%s')", attachment.getContentId(), attachment.getContentType()));
             }
 
+            if (soapMessage.getMtomEnabled()) {
+                if (soapRequest instanceof SaajSoapMessage) {
+                    log.debug("Converting SaajSoapMessage to XOP package");
+                    ((SaajSoapMessage) soapRequest).convertToXopPackage();
+                } else if (soapRequest instanceof AxiomSoapMessage) {
+                    log.warn("AxiomSoapMessage cannot be converted to XOP package");
+                }
+            }
+
             soapRequest.addAttachment(attachment.getContentId(), new InputStreamSource() {
                 public InputStream getInputStream() throws IOException {
                     return attachment.getInputStream();

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/validation/SimpleSoapAttachmentValidator.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/validation/SimpleSoapAttachmentValidator.java
@@ -13,32 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.consol.citrus.ws.validation;
 
+import com.consol.citrus.exceptions.CitrusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import com.consol.citrus.ws.message.SoapAttachment;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
 
 /**
- * Simple implementation of a {@link AbstractSoapAttachmentValidator}. 
- * 
+ * Simple implementation of a {@link AbstractSoapAttachmentValidator}.
+ *
  * Attachment content body is validated through simple string equals assertion.
- *  
+ *
  * @author Christoph Deppisch
  */
 public class SimpleSoapAttachmentValidator extends AbstractSoapAttachmentValidator {
 
-	private boolean ignoreAllWhitespaces = false;
-	
+    private boolean ignoreAllWhitespaces = false;
+
     /**
      * Logger
      */
     private static Logger log = LoggerFactory.getLogger(SimpleSoapAttachmentValidator.class);
-    
+
     @Override
     protected void validateAttachmentContent(SoapAttachment receivedAttachment, SoapAttachment controlAttachment) {
         if (log.isDebugEnabled()) {
@@ -46,48 +48,52 @@ public class SimpleSoapAttachmentValidator extends AbstractSoapAttachmentValidat
             log.debug("Received attachment content: " + StringUtils.trimWhitespace(receivedAttachment.getContent()));
             log.debug("Control attachment content: " + StringUtils.trimWhitespace(controlAttachment.getContent()));
         }
-        
-        if (receivedAttachment.getContent() != null) {
-            Assert.isTrue(controlAttachment.getContent() != null, 
-                    "Values not equal for attachment content '"
-                        + controlAttachment.getContentId() + "', expected '"
-                        + null + "' but was '"
-                        + receivedAttachment.getContent().trim() + "'");
 
-        	String trimmedControlAttachment;
-        	String trimmedReceivedAttachment;
-            
+        if (receivedAttachment.getContent() != null && controlAttachment.getContent() != null) {
+            Assert.isTrue(controlAttachment.getContent() != null,
+                    "Values not equal for attachment content '"
+                    + controlAttachment.getContentId() + "', expected '"
+                    + null + "' but was '"
+                    + receivedAttachment.getContent().trim() + "'");
+
+            String trimmedControlAttachment;
+            String trimmedReceivedAttachment;
+
             if (ignoreAllWhitespaces) {
-            	trimmedControlAttachment = StringUtils.trimAllWhitespace(controlAttachment.getContent());
-            	trimmedReceivedAttachment = StringUtils.trimAllWhitespace(receivedAttachment.getContent());
+                trimmedControlAttachment = StringUtils.trimAllWhitespace(controlAttachment.getContent());
+                trimmedReceivedAttachment = StringUtils.trimAllWhitespace(receivedAttachment.getContent());
             } else {
-            	trimmedControlAttachment = StringUtils.trimWhitespace(controlAttachment.getContent());
-            	trimmedReceivedAttachment = StringUtils.trimWhitespace(receivedAttachment.getContent());
+                trimmedControlAttachment = StringUtils.trimWhitespace(controlAttachment.getContent());
+                trimmedReceivedAttachment = StringUtils.trimWhitespace(receivedAttachment.getContent());
             }
-            
+
             Assert.isTrue(trimmedReceivedAttachment.equals(trimmedControlAttachment),
                     "Values not equal for attachment content '"
-                        + controlAttachment.getContentId() + "', expected '"
-                        + controlAttachment.getContent().trim() + "' but was '"
-                        + receivedAttachment.getContent().trim() + "'");
+                    + controlAttachment.getContentId() + "', expected '"
+                    + controlAttachment.getContent().trim() + "' but was '"
+                    + receivedAttachment.getContent().trim() + "'");
         } else {
-            Assert.isTrue(controlAttachment.getContent() == null || controlAttachment.getContent().trim().length() == 0, 
-                    "Values not equal for attachment content '"
-                        + controlAttachment.getContentId() + "', expected '"
-                        + controlAttachment.getContent().trim() + "' but was '"
-                        + null + "'");
+            // At least one of the attachments has binary data therefore do a binary validation
+            try {
+                Assert.isTrue(IOUtils.contentEquals(receivedAttachment.getInputStream(), controlAttachment.getInputStream()),
+                    "Values not equal for binary attachment content '"
+                    + controlAttachment.getContentId() + "'");
+            }
+            catch(IOException e) {
+                throw new CitrusRuntimeException("Binary attachment validation failed", e);
+            }
         }
-        
+
         if (log.isDebugEnabled()) {
             log.debug("Validating attachment content: OK");
         }
     }
 
-	public boolean isIgnoreAllWhitespaces() {
-		return ignoreAllWhitespaces;
-	}
+    public boolean isIgnoreAllWhitespaces() {
+        return ignoreAllWhitespaces;
+    }
 
-	public void setIgnoreAllWhitespaces(boolean ignoreAllWhitespaces) {
-		this.ignoreAllWhitespaces = ignoreAllWhitespaces;
-	}
+    public void setIgnoreAllWhitespaces(boolean ignoreAllWhitespaces) {
+        this.ignoreAllWhitespaces = ignoreAllWhitespaces;
+    }
 }


### PR DESCRIPTION
Bug fixes:
* Support loading of WSDL files and their imports from jar files

Enhancements:
* Support of mtom for attachements (XOP package), new attribute "mtom-enabled" (defaults to false)
* Support mtom xop references and mtom inline data with auto-detection of data type, new attribute "mtom-inline" (defaults to false)
* Binary attachment support (no dynamic data replacement, no string conversion) based on content type
* Improved handling of dynamic content in attachments
* Added "schema-repository" to SendSoapMessageAction to support defining a custom schema repository to resolve mtom attachments
* Added SOAP mtom attachment integration test

Known issue:
* Schema validation for SOAP messages with MTOM attachments (not inline) is not working, because the XOP reference is not valid data. To support schema validation, XOP references need to be resolved and attachments must be inlined before validation. Inline MTOM attachments are validated successfully. An example of this issue is added to the integration tests.
