### PR TITLE
Fix HTTP Server Response Message Tracing

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/interceptor/LoggingHandlerInterceptor.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/interceptor/LoggingHandlerInterceptor.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -151,17 +152,21 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
      */
     private String getResponseContent(HttpServletResponse response, Object handler) {
         StringBuilder builder = new StringBuilder();
-        
+
         builder.append(response);
-        
-        if (handler instanceof HttpMessageController) {
-            ResponseEntity<String> responseEntity = ((HttpMessageController)handler).getResponseCache();
-            if (responseEntity != null) {
-                builder.append(NEWLINE);
-                builder.append(responseEntity.getBody());
+
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+            if (handlerMethod.getBean() instanceof HttpMessageController) {
+                ResponseEntity<String> responseEntity =
+                        ((HttpMessageController) handlerMethod.getBean()).getResponseCache();
+                if (responseEntity != null) {
+                    builder.append(NEWLINE);
+                    builder.append(responseEntity.getBody());
+                }
             }
         }
-        
+
         return builder.toString();
     }
 


### PR DESCRIPTION
The response body of an HTTP server was not traced via the MessageTracingTestListener.
The http headers appeared in the trace log, but the body was missing.

To fix the problem, the HttpMessageController was unwrapped from the HandlerMethod object.