### PR TITLE
Fixed XML schema validation of WSDL based schemas. When a WSDL is imp…

### DIFF
--- a/modules/citrus-integration/src/citrus/java/com/consol/citrus/validation/ValidateWSDLWithImportsITest.java
+++ b/modules/citrus-integration/src/citrus/java/com/consol/citrus/validation/ValidateWSDLWithImportsITest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2006-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.validation;
+
+import com.consol.citrus.annotations.CitrusXmlTest;
+import com.consol.citrus.testng.AbstractTestNGCitrusTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2008
+ */
+public class ValidateWSDLWithImportsITest extends AbstractTestNGCitrusTest {
+    @Test
+    @CitrusXmlTest
+    public void ValidateWSDLWithImports() {}
+}

--- a/modules/citrus-integration/src/citrus/resources/citrus-context.xml
+++ b/modules/citrus-integration/src/citrus/resources/citrus-context.xml
@@ -91,11 +91,11 @@
          message-factory="messageFactory"/>
 
     <!-- SOAP test client -->
-    <citrus-ws:client id="imageServiceClient"
+    <citrus-ws:client id="testWebServiceClient"
                       request-url="http://localhost:8091"/>
 
     <!-- SOAP test server -->
-    <citrus-ws:server id="imageSoapServer"
+    <citrus-ws:server id="testSoapServer"
                       port="8091" 
                       auto-start="true"
                       resource-base="src/citrus/resources"/>    

--- a/modules/citrus-integration/src/citrus/resources/citrus-schemas-context.xml
+++ b/modules/citrus-integration/src/citrus/resources/citrus-schemas-context.xml
@@ -33,4 +33,10 @@
     </citrus:schemas>
   </citrus:schema-repository>
 
+  <citrus:schema-repository id="sampleServiceSchemaRepository">
+    <citrus:schemas>
+      <citrus:schema id="sampleServiceSchema" location="classpath:com/consol/citrus/schema/SampleServiceWithImports.wsdl" />
+    </citrus:schemas>
+  </citrus:schema-repository>
+
 </beans>

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleMessage.xsd
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleMessage.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns="http://www.citrusframework.org/SampleService/Message"
+		   targetNamespace="http://www.citrusframework.org/SampleService/Message"
+		   xmlns:types="http://www.citrusframework.org/SampleService/Types"
+		   elementFormDefault="unqualified"
+		   attributeFormDefault="unqualified">
+
+	<!-- Import dependency XML schema to test schema loading -->
+	<xs:import namespace="http://www.citrusframework.org/SampleService/Types" schemaLocation="SampleTypes.xsd"/>
+
+	<xs:complexType name="SampleMessageType">
+		<xs:sequence>
+			<xs:element name="hello" type="xs:string"/>
+			<xs:element name="test" type="types:SampleType"/>
+		</xs:sequence>
+	</xs:complexType>
+
+<xs:element name="sampleMessage2" type="SampleMessageType"/>
+
+</xs:schema>

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleMessageResponse.xsd
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleMessageResponse.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns="http://www.citrusframework.org/SampleService/MessageResponse"
+		   targetNamespace="http://www.citrusframework.org/SampleService/MessageResponse"
+		   xmlns:types="http://www.citrusframework.org/SampleService/Types"
+		   elementFormDefault="unqualified"
+		   attributeFormDefault="unqualified">
+
+	<!-- Import dependency XML schema to test schema loading -->
+	<xs:import namespace="http://www.citrusframework.org/SampleService/Types" schemaLocation="SampleTypes.xsd"/>
+
+	<xs:complexType name="SampleMessageResponseType">
+		<xs:sequence>
+			<xs:element name="reply" type="xs:string"/>
+			<xs:element name="test" type="types:SampleType"/>
+		</xs:sequence>
+	</xs:complexType>
+
+</xs:schema>

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleServiceWithImports.wsdl
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleServiceWithImports.wsdl
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/soap/"
+				  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+				  xmlns:tns="http://www.citrusframework.org/SampleService/"
+				  xmlns:commands="http://www.citrusframework.org/SampleService/Commands"
+				  xmlns:types="http://www.citrusframework.org/types/"
+				  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+				  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+				  name="SampleService"
+				  targetNamespace="http://www.citrusframework.org/SampleService/">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://www.citrusframework.org/SampleService/Commands"
+					xmlns="http://www.citrusframework.org/SampleService/Commands"
+					xmlns:xs="http://www.w3.org/2001/XMLSchema"
+					xmlns:sample-message="http://www.citrusframework.org/SampleService/Message"
+					xmlns:sample-message-response="http://www.citrusframework.org/SampleService/MessageResponse">
+
+			<!-- Import two XML schemas to test schema loading -->
+			<xs:import namespace="http://www.citrusframework.org/SampleService/Message" schemaLocation="SampleMessage.xsd"/>
+			<xs:import namespace="http://www.citrusframework.org/SampleService/MessageResponse" schemaLocation="SampleMessageResponse.xsd"/>
+
+			<xs:complexType name="SampleMessageType2">
+				<xs:sequence>
+					<xs:element name="hello" type="xs:string"/>
+					<xs:element name="test" type="xs:string"/>
+				</xs:sequence>
+			</xs:complexType>			
+
+			<xsd:element name="sampleMessage" type="sample-message:SampleMessageType"/>
+			<!--<xs:element name="sampleMessage" type="SampleMessageType2"/>-->
+			<xs:element name="sampleMessageResponse" type="sample-message-response:SampleMessageResponseType"/>
+		</xsd:schema>
+	</wsdl:types>
+
+	<wsdl:message name="sampleMessage">
+		<wsdl:part element="commands:sampleMessage" name="parameters"/>
+	</wsdl:message>
+	<wsdl:message name="sampleMessageResponse">
+		<wsdl:part element="commands:sampleMessageResponse" name="parameters"/>
+	</wsdl:message>
+
+	<wsdl:portType name="SampleService">
+		<wsdl:operation name="sampleMessage">
+			<wsdl:input message="tns:sampleMessage"/>
+			<wsdl:output message="tns:sampleMessageResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:binding name="SampleServiceSOAP" type="tns:SampleService">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="sampleMessage">
+			<soap:operation soapAction="http://www.citrusframework.org/sample/sampleMessage"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+
+	<wsdl:service name="SampleService">
+		<wsdl:port binding="tns:SampleServiceSOAP" name="SampleServiceSOAP">
+			<soap:address location="http://www.citrusframework.org/SampleService/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleTypes.xsd
+++ b/modules/citrus-integration/src/citrus/resources/com/consol/citrus/schema/SampleTypes.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns="http://www.citrusframework.org/SampleService/Types"
+		   targetNamespace="http://www.citrusframework.org/SampleService/Types"
+		   elementFormDefault="unqualified"
+		   attributeFormDefault="unqualified">
+
+	<xs:simpleType name="SampleType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="FOO"/>
+			<xs:enumeration value="BAR"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/modules/citrus-integration/src/citrus/tests/com/consol/citrus/validation/ValidateWSDLWithImports.xml
+++ b/modules/citrus-integration/src/citrus/tests/com/consol/citrus/validation/ValidateWSDLWithImports.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+			  xmlns:spring="http://www.springframework.org/schema/beans"
+			  xmlns:ws="http://www.citrusframework.org/schema/ws/testcase"
+			  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                                  http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd
+                                  http://www.citrusframework.org/schema/ws/testcase http://www.citrusframework.org/schema/ws/testcase/citrus-ws-testcase.xsd">
+
+	<testcase name="ValidateWSDLWithImports">
+		<meta-info>
+			<author>Reinhard Steiner</author>
+			<creationdate>2015-10-27</creationdate>
+			<status>FINAL</status>
+		</meta-info>
+
+		<description>Validating SOAP message with special WSDL using imports</description>
+
+		<actions>
+
+			<echo>
+				<message>Test: Sending valid SOAP message</message>
+			</echo>
+
+			<parallel>
+				<send endpoint="testWebServiceClient">
+					<message>
+						<data>
+                            <![CDATA[
+                                <sample:sampleMessage xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+                                    <hello>Are you there?</hello>
+                                    <test>FOO</test>
+                                </sample:sampleMessage>
+                            ]]>
+						</data>
+					</message>
+				</send>
+
+				<sequential>
+					<receive endpoint="testSoapServer">
+						<message schema-repository="sampleServiceSchemaRepository">
+							<data>
+								<![CDATA[
+									<sample:sampleMessage xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+										<hello>Are you there?</hello>
+										<test>FOO</test>
+									</sample:sampleMessage>
+								]]>
+							</data>
+						</message>
+					</receive>
+
+					<send endpoint="testSoapServer">
+						<message>
+							<data>
+								<![CDATA[
+									<sample:sampleMessageResponse xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+										<reply>Yes!</reply>
+										<test>BAR</test>
+									</sample:sampleMessageResponse>
+								]]>
+							</data>
+						</message>
+					</send>
+				</sequential>
+			</parallel>
+
+			<receive endpoint="testWebServiceClient">
+				<message schema-repository="sampleServiceSchemaRepository">
+					<data>
+						<![CDATA[
+							<sample:sampleMessageResponse xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+								<reply>Yes!</reply>
+								<test>BAR</test>
+							</sample:sampleMessageResponse>
+						]]>
+					</data>
+				</message>
+			</receive>
+
+			<echo>
+				<message>Test: Sending invalid SOAP message</message>
+			</echo>
+
+			<parallel>
+				<send endpoint="testWebServiceClient">
+					<message>
+						<data>
+                            <![CDATA[
+                                <sample:sampleMessage xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+                                    <hello>Are you there?</hello>
+                                    <test>FOO-wrong</test>
+                                </sample:sampleMessage>
+                            ]]>
+						</data>
+					</message>
+				</send>
+
+				<sequential>
+					<assert exception="com.consol.citrus.exceptions.ValidationException">
+						<receive endpoint="testSoapServer">
+							<message schema-repository="sampleServiceSchemaRepository">
+								<data>
+									<![CDATA[
+										<sample:sampleMessage xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+											<hello>Are you there?</hello>
+											<test>FOO-wrong</test>
+										</sample:sampleMessage>
+									]]>
+								</data>
+							</message>
+						</receive>
+					</assert>
+
+					<send endpoint="testSoapServer">
+						<message>
+							<data>
+								<![CDATA[
+									<sample:sampleMessageResponse xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+										<reply>Yes!</reply>
+										<test>BAR-wrong</test>
+									</sample:sampleMessageResponse>
+								]]>
+							</data>
+						</message>
+					</send>
+				</sequential>
+			</parallel>
+
+			<assert exception="com.consol.citrus.exceptions.ValidationException">
+				<receive endpoint="testWebServiceClient">
+					<message schema-repository="sampleServiceSchemaRepository">
+						<data>
+							<![CDATA[
+								<sample:sampleMessageResponse xmlns:sample="http://www.citrusframework.org/SampleService/Commands">
+									<reply>Yes!</reply>
+									<test>BAR-wrong</test>
+								</sample:sampleMessageResponse>
+							]]>
+						</data>
+					</message>
+				</receive>
+			</assert>
+
+		</actions>
+	</testcase>
+</spring:beans>

--- a/modules/citrus-integration/src/citrus/tests/com/consol/citrus/ws/SendSoapMessageWithMtomAttachmentITest.xml
+++ b/modules/citrus-integration/src/citrus/tests/com/consol/citrus/ws/SendSoapMessageWithMtomAttachmentITest.xml
@@ -29,7 +29,7 @@
             </echo>
 
             <parallel>
-            	<ws:send endpoint="imageServiceClient" mtom-enabled="true">
+            	<ws:send endpoint="testWebServiceClient" mtom-enabled="true">
                     <message>
                         <data>
                             <![CDATA[
@@ -47,7 +47,7 @@
                 </ws:send>
                                 
                 <sequential>
-                    <ws:receive endpoint="imageSoapServer">
+                    <ws:receive endpoint="testSoapServer">
                         <message schema-validation="false">
                             <data>
                                 <![CDATA[
@@ -64,7 +64,7 @@
                         </ws:attachment>
                     </ws:receive>
                     
-                    <ws:send endpoint="imageSoapServer">
+                    <ws:send endpoint="testSoapServer">
                         <message>
                             <data>
                                 <![CDATA[
@@ -78,7 +78,7 @@
                 </sequential>
             </parallel>
             
-            <ws:receive endpoint="imageServiceClient">
+            <ws:receive endpoint="testWebServiceClient">
                 <message schema-repository="imageServiceSchemaRepository">
                     <data>
                         <![CDATA[
@@ -95,7 +95,7 @@
             </echo>
 
             <parallel>
-            	<ws:send endpoint="imageServiceClient" mtom-enabled="true">
+            	<ws:send endpoint="testWebServiceClient" mtom-enabled="true">
                     <message>
                         <data>
                             <![CDATA[
@@ -116,7 +116,7 @@
                 </ws:send>
                                 
                 <sequential>
-                    <ws:receive endpoint="imageSoapServer">
+                    <ws:receive endpoint="testSoapServer">
                         <message schema-validation="false">
                             <data>
                                 <![CDATA[
@@ -136,7 +136,7 @@
                         </ws:attachment>
                     </ws:receive>
                     
-                    <ws:send endpoint="imageSoapServer">
+                    <ws:send endpoint="testSoapServer">
                         <message>
                             <data>
                                 <![CDATA[
@@ -150,7 +150,7 @@
                 </sequential>
             </parallel>
             
-            <ws:receive endpoint="imageServiceClient">
+            <ws:receive endpoint="testWebServiceClient">
                 <message schema-repository="imageServiceSchemaRepository">
                     <data>
                         <![CDATA[
@@ -167,7 +167,7 @@
             </echo>
 
             <parallel>
-            	<ws:send endpoint="imageServiceClient" mtom-enabled="true">
+            	<ws:send endpoint="testWebServiceClient" mtom-enabled="true">
                     <message>
                         <data>
                             <![CDATA[
@@ -188,7 +188,7 @@
                 </ws:send>
                 
                 <sequential>
-                    <ws:receive endpoint="imageSoapServer">
+                    <ws:receive endpoint="testSoapServer">
                         <message schema-repository="imageServiceSchemaRepository">
                             <data>
                                 <![CDATA[
@@ -202,7 +202,7 @@
                         </message>
                     </ws:receive>
                     
-                    <ws:send endpoint="imageSoapServer">
+                    <ws:send endpoint="testSoapServer">
                         <message>
                             <data>
                                 <![CDATA[
@@ -216,7 +216,7 @@
                 </sequential>
             </parallel>
             
-            <ws:receive endpoint="imageServiceClient">
+            <ws:receive endpoint="testWebServiceClient">
                 <message schema-repository="imageServiceSchemaRepository">
                     <data>
                         <![CDATA[


### PR DESCRIPTION
Fixed XML schema validation of WSDL based schemas.

When a WSDL is importing multiple schemas, the current validation loaded the schemas in the wrong order. The order is important for the XmlValidatorFactory.createValidator to create a schema validator. This factory needs to know every type when it is used. Meaning for example, when a WSDL schema imports a schema SA with a type TA and uses it, the schema SA needs to be in the returned resource array "before" the WSDL schema, otherwise building a validator will fail with an exception that type TA is unknown.
This was implemented correct for all imported schemas (first add imported schemas before the parent schema to the resource array), but wrong for the embedded WSDL schema (root schema) which was added on position 0 instead of at the end. Added an integration test to test this behavior.