### PR TITLE
Fix typo "paylaod" --> "payload"

### DIFF
--- a/modules/citrus-mail/src/main/java/com/consol/citrus/mail/message/MailMessageConverter.java
+++ b/modules/citrus-mail/src/main/java/com/consol/citrus/mail/message/MailMessageConverter.java
@@ -348,7 +348,7 @@ public class MailMessageConverter implements MessageConverter<MimeMailMessage, M
         }
 
         if (mailMessage == null) {
-            throw new CitrusRuntimeException("Unable to create proper mail message from paylaod: " + payload);
+            throw new CitrusRuntimeException("Unable to create proper mail message from payload: " + payload);
         }
 
         return mailMessage;

--- a/modules/citrus-mail/src/main/java/com/consol/citrus/mail/server/MailServer.java
+++ b/modules/citrus-mail/src/main/java/com/consol/citrus/mail/server/MailServer.java
@@ -115,7 +115,7 @@ public class MailServer extends AbstractServer implements SimpleMessageListener,
         }
 
         if (acceptResponse == null) {
-            throw new CitrusRuntimeException("Unable to read accept response from paylaod: " + response);
+            throw new CitrusRuntimeException("Unable to read accept response from payload: " + response);
         }
 
         return acceptResponse.isAccept();

--- a/modules/citrus-ssh/src/main/java/com/consol/citrus/ssh/message/SshMessageConverter.java
+++ b/modules/citrus-ssh/src/main/java/com/consol/citrus/ssh/message/SshMessageConverter.java
@@ -45,7 +45,7 @@ public class SshMessageConverter implements MessageConverter<SshMessage, SshEndp
         }
 
         if (sshMessage == null) {
-            throw new CitrusRuntimeException("Unable to create proper ssh message from paylaod: " + payload);
+            throw new CitrusRuntimeException("Unable to create proper ssh message from payload: " + payload);
         }
 
         return sshMessage;

--- a/src/docbkx/actions-receive.xml
+++ b/src/docbkx/actions-receive.xml
@@ -166,7 +166,7 @@ public void messagingTest() {
         .payloadModel(new TestRequest("Hello Citrus!"), "myMessageMarshallerBean");
 }</programlisting>
 
-      <para>Now Citrus will marshal the message paylaod with the message marshaller bean named <emphasis>myMessageMarshallerBean</emphasis>.
+      <para>Now Citrus will marshal the message payload with the message marshaller bean named <emphasis>myMessageMarshallerBean</emphasis>.
         This way you can have multiple message marshaller implementations active in your project (XML, JSON, and so on).</para>
 
       <para>Last not least the message can be defined as Citrus message object. Here you can choose one of the different message implementations used in Citrus for SOAP, Http or JMS messages. Or you just use the default message implementation or maybe a custom

--- a/src/docbkx/actions-send.xml
+++ b/src/docbkx/actions-send.xml
@@ -239,7 +239,7 @@ public void messagingTest() {
         .payloadModel(new TestRequest("Hello Citrus!"), "myMessageMarshallerBean");
 }</programlisting>
 
-    <para>Now Citrus will marshal the message paylaod with the message marshaller bean named <emphasis>myMessageMarshallerBean</emphasis>.
+    <para>Now Citrus will marshal the message payload with the message marshaller bean named <emphasis>myMessageMarshallerBean</emphasis>.
     This way you can have multiple message marshaller implementations active in your project (XML, JSON, and so on).</para>
 
     <para>Last not least the message can be defined as Citrus message object. Here you can choose one of the different message implementations used in Citrus for SOAP, Http or JMS messages. Or you just use the default message implementation or maybe a custom


### PR DESCRIPTION
I fixed the typo in `paylaod` to `payload`. I am not sure if the exception message in `CitrusRuntimeException` is parsed somewhere, in which case this change could lead to incompatibilities. Otherwise, the change is a very small one.