### PR TITLE
Added 'root-parent-context' to citrus-ws:server for SOAP1.2

### DIFF
--- a/src/docbkx/soap.xml
+++ b/src/docbkx/soap.xml
@@ -372,6 +372,7 @@
 &lt;citrus-ws:server id=&quot;soap12Server&quot;
           port=&quot;8080&quot;
           auto-start=&quot;true&quot;
+          root-parent-context=&quot;true&quot;
           message-factory=&quot;soap12MessageFactory&quot;/&gt;</programlisting>
 
       <para>By default Citrus components do connect with a message factory called <emphasis>messageFactory</emphasis> no matter what SOAP version this factory is using.</para>


### PR DESCRIPTION
After some struggle getting `citrus-ws:server` to work with SOAP 1.2 using the documentation [1], I found the trick after debugging the code and reading an example [2] by adding `root-parent-context="true"` to `citrus-ws:server`.
To save this time for others, I added this line to the documentation

[1] http://citrusframework.org/reference/html/index.html#soap-12
[2] https://github.com/christophd/citrus/blob/master/modules/citrus-ws/src/test/resources/citrus-context.xml