### PR TITLE
Fix unescaped brackets

### DIFF
--- a/src/manual/actions-database.md
+++ b/src/manual/actions-database.md
@@ -213,7 +213,7 @@ Next example shows how to work with multiple row result sets and multiple values
       
 ```
 
-For the validation of multiple rows the ***<validate>*** element is able to host a list of control values for a column. As you can see from the example above, you have to add a control value for each row in the result set. This also means that we have to take care of the total number of rows. Fortunately we can use the ignore placeholder, in order to skip the validation of a specific row in the result set. Functions and variables are supported as usual.
+For the validation of multiple rows the ***`<validate>`*** element is able to host a list of control values for a column. As you can see from the example above, you have to add a control value for each row in the result set. This also means that we have to take care of the total number of rows. Fortunately we can use the ignore placeholder, in order to skip the validation of a specific row in the result set. Functions and variables are supported as usual.
 
 **Important**
 It is important, that the control values are defined in the correct order, because they are compared one on one with the actual result set coming from database query. You may need to add "order by" SQL expressions to get the right order of rows returned. If any of the values fails in validation or the total number of rows is not equal, the whole action will fail with respective validation errors.

--- a/src/manual/actions-receive.md
+++ b/src/manual/actions-receive.md
@@ -105,7 +105,7 @@ So by defining an expected message payload we validate the incoming message in s
 The three examples above represent three different ways of defining the message payload in a receive message action. On the one hand we can use inline message payloads as nested XML or CDATA sections in the test. On the other hand we can load the message content from external file resource.
 
 **Note**
-Sometimes the nested XML message payload elements may cause XSD schema validation rule violations. This is because of variable values not fitting the XSD schema rules for example. In this scenario you could also use simple CDATA sections as payload data. In this case you need to use the ***<data>*** element in contrast to the ***<payload>*** element that we have used in our examples so far.
+Sometimes the nested XML message payload elements may cause XSD schema validation rule violations. This is because of variable values not fitting the XSD schema rules for example. In this scenario you could also use simple CDATA sections as payload data. In this case you need to use the ***`<data>`*** element in contrast to the ***`<payload>`*** element that we have used in our examples so far.
 
 With this alternative you can skip the XML schema validation from your IDE at design time. Unfortunately you will loose the XSD auto completion features many XML editors offer when constructing your payload.
 
@@ -220,7 +220,7 @@ Header definition in Java DSL is straight forward as we just define name and val
 
 ### Message selectors
 
-The **<selector>** element inside the receiving action defines key-value pairs in order to filter the messages being received. The filter applies to the message headers. This means that a receiver will only accept messages matching a header element value. In messaging applications the header information often holds message ids, correlation ids, operation names and so on. With this information given you can explicitly listen for messages that belong to your test case. This is very helpful to avoid receiving messages that are still available on the message destination.
+The **`<selector>`** element inside the receiving action defines key-value pairs in order to filter the messages being received. The filter applies to the message headers. This means that a receiver will only accept messages matching a header element value. In messaging applications the header information often holds message ids, correlation ids, operation names and so on. With this information given you can explicitly listen for messages that belong to your test case. This is very helpful to avoid receiving messages that are still available on the message destination.
 
 Lets say the tested software application keeps sending messages that belong to previous test cases. This could happen in retry situations where the application error handling automatically tries to solve a communication problem that occurred during previous test cases. As a result a message destination (e.g. a JMS message queue) contains messages that are not valid any more for the currently running test case. The test case might fail because the received message does not apply to the actual use case. So we will definitely run into validation errors as the expected message control values do not match.
 

--- a/src/manual/actions-send.md
+++ b/src/manual/actions-send.md
@@ -44,7 +44,7 @@ Now lets have a closer look at the sending action. The **'endpoint'** attribute 
 
 The test case is not aware of any transport details, because it does not have to. The advantages are obvious: On the one hand multiple test cases can reference the message endpoint definition for better reuse. Secondly test cases are independent of message transport details. So connection factories, user credentials, endpoint uri values and so on are not present in the test case.
 
-In other words the **"endpoint"** attribute of the **<send>** element specifies which message endpoint definition to use and therefore where the message should go to. Once again all available message endpoints are configured in a separate Citrus configuration file. We will come to this later on. Be sure to always pick the right message endpoint type in order to publish your message to the right destination.
+In other words the **"endpoint"** attribute of the **`<send>`** element specifies which message endpoint definition to use and therefore where the message should go to. Once again all available message endpoints are configured in a separate Citrus configuration file. We will come to this later on. Be sure to always pick the right message endpoint type in order to publish your message to the right destination.
 
 If you do not like the XML language you can also use pure Java code to define the same test. In Java you would also make use of the message endpoint definition and reference this instance. The same test as shown above in Java DSL looks like this:
 
@@ -165,7 +165,7 @@ The file path prefix indicates the resource type, so the file location is resolv
 The most important thing when dealing with sending actions is to prepare the message payload and header. You are able to construct the message payload either by nested XML child nodes (payload), as inline CDATA (<data>) or external file (<resource>).
 
 **Note**
-Sometimes the nested XML message payload elements may cause XSD schema validation rule violations. This is because of variable values not fitting the XSD schema rules for example. In this scenario you could also use simple CDATA sections as payload data. In this case you need to use the ***<data>*** element in contrast to the ***<payload>*** element that we have used in our examples so far.
+Sometimes the nested XML message payload elements may cause XSD schema validation rule violations. This is because of variable values not fitting the XSD schema rules for example. In this scenario you could also use simple CDATA sections as payload data. In this case you need to use the ***`<data>`*** element in contrast to the ***`<payload>`*** element that we have used in our examples so far.
 
 With this alternative you can skip the XML schema validation from your IDE at design time. Unfortunately you will loose the XSD auto completion features many XML editors offer when constructing your payload.
 

--- a/src/manual/actions-transform.md
+++ b/src/manual/actions-transform.md
@@ -1,6 +1,6 @@
 ### Transform
 
-The ***<transform>*** action transforms XML fragments with XSLT in order to construct various XML representations. The transformation result is stored into a test variable for further usage. The property **xml-data** defines the XML source, that is going to be transformed, while **xslt-data** defines the XSLT transformation rules. The attribute **variable** specifies the target test variable which receives the transformation result. The tester might use the action to transform XML messages as shown in the next code example:
+The ***`<transform>`*** action transforms XML fragments with XSLT in order to construct various XML representations. The transformation result is stored into a test variable for further usage. The property **xml-data** defines the XML source, that is going to be transformed, while **xslt-data** defines the XSLT transformation rules. The attribute **variable** specifies the target test variable which receives the transformation result. The tester might use the action to transform XML messages as shown in the next code example:
 
 **XML DSL** 
 

--- a/src/manual/endpoints.md
+++ b/src/manual/endpoints.md
@@ -63,7 +63,7 @@ Now lets have a closer look at the sending action. The **'endpoint'** attribute 
 
 The test case is not aware of any transport details, because it does not have to. The advantages are obvious: On the one hand multiple test cases can reference the message endpoint definition for better reuse. Secondly test cases are independent of message transport details. So connection factories, user credentials, endpoint uri values and so on are not present in the test case.
 
-In other words the **"endpoint"** attribute of the **<send>** element specifies which message endpoint definition to use and therefore where the message should go to. Once again all available message endpoints are configured in a separate Citrus configuration file. Be sure to always pick the right message endpoint type in order to publish your message to the right destination.
+In other words the **"endpoint"** attribute of the **`<send>`** element specifies which message endpoint definition to use and therefore where the message should go to. Once again all available message endpoints are configured in a separate Citrus configuration file. Be sure to always pick the right message endpoint type in order to publish your message to the right destination.
 
 If you do not like the XML language you can also use pure Java code to define the same test. In Java you would also make use of the message endpoint definition and reference this instance. The same test as shown above in Java DSL looks like this:
 

--- a/src/manual/functions.md
+++ b/src/manual/functions.md
@@ -477,7 +477,7 @@ Usually we use CDATA sections to define message payload data inside a testcase. 
 <variable name="cdata" value="citrus:cdataSection('payload')"/>
 ```
 
-cdata = **<![CDATA[payload]]>** 
+cdata = **`<![CDATA[payload]]>`** 
 
 ### citrus:digestAuthHeader()
 
@@ -519,7 +519,7 @@ Test cases may use the local host address for some reason (e.g. used as authenti
 
 A possible value is either the host name as used in DNS entry or an IP address value:
 
-address = **<192.168.2.100>** 
+address = **`<192.168.2.100>`** 
 
 ### citrus:changeDate()
 

--- a/src/manual/samples-flightbooking.md
+++ b/src/manual/samples-flightbooking.md
@@ -370,7 +370,7 @@ Similar to a sequence diagram the test case describes every step of the use case
 
 The sending/receiving actions use a previously defined message sender/receiver. This is the link between test case and basic Spring configuration we have done before.
 
-***<send endpoint="travelAgencyBookingRequestEndpoint">*** 
+***`send endpoint="travelAgencyBookingRequestEndpoint"`*** 
 
 The sending action chooses a message sender to actually send the message using a message transport (JMS, Http, SOAP, etc.). After sending this first "TravelBookingRequestMessage" request the test case expects the first "FlightBookingRequestMessage" message on the SmartAirline JMS destination. In case this message is not arriving in time the test will fail with errors. In positive case our FlightBookingService works well and the message arrives in time. The received message is validated against a defined expected message template. Only in case all content validation steps are successful the test continues with the action chain. And so the test case proceeds and works through the use case until every message is sent respectively received and validated. The use case is done automatically without human interaction. Citrus simulates all surrounding applications and provides detailed validation possibilities of messages.
 

--- a/src/manual/soap.md
+++ b/src/manual/soap.md
@@ -538,7 +538,7 @@ Server: Jetty(7.0.0.pre5)
 ```
 
 **Important**
-Notice that the send action uses a special XML namespace (ws:send). This ws namespace belongs to the Citrus WebService extension and adds SOAP specific features to the normal send action. When you use such ws extensions you need to define the additional namespace in your test case. This is usually done in the root **<spring:beans>** element where we simply declare the citrus-ws specific namespace like follows.```xml
+Notice that the send action uses a special XML namespace (ws:send). This ws namespace belongs to the Citrus WebService extension and adds SOAP specific features to the normal send action. When you use such ws extensions you need to define the additional namespace in your test case. This is usually done in the root **`<spring:beans>`** element where we simply declare the citrus-ws specific namespace like follows.```xml
 <spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
     xmlns:spring="http://www.springframework.org/schema/beans"
     xmlns:ws="http://www.citrusframework.org/schema/ws/testcase"

--- a/src/manual/ssh.md
+++ b/src/manual/ssh.md
@@ -119,7 +119,7 @@ Given the above SSH module namespace declaration, adding a new SSH server is qui
 
 **endpoint-adapter** is the handler which receives the SSH request as messages (in the request format described above). Endpoint adapter implementations are fully described in[http-server](http-server)All adapters described there are supported in SSH server module, too.
 
-The **<citrus-ssh:server>** supports the following attributes:
+The **`<citrus-ssh:server>`** supports the following attributes:
 
 **SSH Server Attributes:** 
 

--- a/src/manual/test-case.md
+++ b/src/manual/test-case.md
@@ -70,7 +70,7 @@ The custom XML schema aims to reach the convenience of domain specific languages
 </spring:beans>
 ```
 
-We do need the ***<spring:beans>*** root element as the XML file is read by the Spring IoC container. Inside this root element the Citrus specific namespace definitions take place.
+We do need the ***`<spring:beans>`*** root element as the XML file is read by the Spring IoC container. Inside this root element the Citrus specific namespace definitions take place.
 
 The test case itself gets a mandatory name that must be unique throughout all test cases in a project. You will receive errors when using duplicate test names. The test name has to follow the common Java naming conventions and rules for Java classes. This means names must not contain any whitespace characters but characters like '-', '.', '_' are supported. For example, ***TestFeature_1*** is valid but ***Test Feature 1*** is not as it contains whitespace characters like spaces.
 

--- a/src/manual/test-variables.md
+++ b/src/manual/test-variables.md
@@ -114,6 +114,6 @@ You can also use a script to create variable values. This is extremely handy whe
 </variables>
 ```
 
-We use the script code right inside the variable value definition. The value of the variable is the result of the last operation performed within the script. For longer script code the use of ***<![CDATA[ ]]>*** sections is recommended.
+We use the script code right inside the variable value definition. The value of the variable is the result of the last operation performed within the script. For longer script code the use of ***`<![CDATA[ ]]>`*** sections is recommended.
 
 Citrus uses the javax ScriptEngine mechanism in order to evaluate the script code. By default Groovy is supported in any Citrus project. So you can add additional ScriptEngine implementations to your project and support other script types, too.

--- a/src/manual/validation-xml.md
+++ b/src/manual/validation-xml.md
@@ -14,11 +14,11 @@ Once Citrus has received a message the tester can validate the message contents 
 
 The receiving action offers following elements for control message templates:
 
-*  **<payload>** : Defines the message payload as nested XML message template. The whole message payload is defined inside the test case.
+*  **`<payload>`** : Defines the message payload as nested XML message template. The whole message payload is defined inside the test case.
 
-*  **<data>** : Defines an inline XML message template as nested CDATA. Slightly different to the payload variation as we define the whole message payload inside the test case as CDATA section.
+*  **`<data>`** : Defines an inline XML message template as nested CDATA. Slightly different to the payload variation as we define the whole message payload inside the test case as CDATA section.
 
-*  **<resource>** : Defines an expected XML message template via external file resources. This time the payload is loaded at runtime from the external file.
+*  **`<resource>`** : Defines an expected XML message template via external file resources. This time the payload is loaded at runtime from the external file.
 
 
 

--- a/src/manual/xpath.md
+++ b/src/manual/xpath.md
@@ -48,7 +48,7 @@ Some elements in XML message payloads might be of dynamic nature. Just think of 
 
 The program listing above shows ways of setting variable values inside a message template. First of all you can simply place variable expressions inside the message (see how ${messageId} is used). In addition to that you can also use XPath expressions to explicitly overwrite message elements before validation.
 
-***<element path="/TestMessage/CreatedBy" value="${user}"/>*** 
+***`<element path="/TestMessage/CreatedBy" value="${user}"/>`*** 
 
 The XPath expression evaluates and searches for the right element in the message payload. The previously defined variable **${user}** replaces the element value. Of course this works with XML attributes too.
 


### PR DESCRIPTION
Text elements describing XML tags (enclosed in '<' and '>') are not displayed in HTML since they are recognized as HTML tags. They must be escaped in Markdown.