### PR TITLE
MS SQL Compatibility fix

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/actions/ExecuteSQLQueryAction.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/actions/ExecuteSQLQueryAction.java
@@ -238,7 +238,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
                 columnName = columnName.toLowerCase();
             } else if (columnValuesMap.containsKey(columnName.toUpperCase())) {
                 columnName = columnName.toUpperCase();
-            } else {
+            } else if (!columnValuesMap.containsKey(columnName)) {
                 throw new CitrusRuntimeException("Could not find column '" + columnName + "' in SQL result set");
             }
 


### PR DESCRIPTION
Change to make it working again with MS SQL when using mixed case column names.