### PR TITLE
enabled access to mtomEnabled flag for soap send actions in java dsl

### DIFF
--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/SoapClientRequestActionBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/SoapClientRequestActionBuilder.java
@@ -170,6 +170,11 @@ public class SoapClientRequestActionBuilder extends SendMessageBuilder<SendSoapM
         soapMessage.header(SoapMessageHeaders.HTTP_ACCEPT, accept);
         return this;
     }
+    
+    public SoapClientRequestActionBuilder mtomEnabled(boolean mtomEnabled) {
+        getAction().setMtomEnabled(mtomEnabled);
+        return this;
+    }
 
     @Override
     protected SendSoapMessageAction getAction() {

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/SoapServerResponseActionBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/SoapServerResponseActionBuilder.java
@@ -145,6 +145,11 @@ public class SoapServerResponseActionBuilder extends SendMessageBuilder<SendSoap
         soapMessage.header(SoapMessageHeaders.HTTP_CONTENT_TYPE, contentType);
         return this;
     }
+    
+    public SoapServerResponseActionBuilder mtomEnabled(boolean mtomEnabled) {
+        getAction().setMtomEnabled(mtomEnabled);
+        return this;
+    }
 
     @Override
     protected SendSoapMessageAction getAction() {

--- a/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/design/SendSoapMessageTestDesignerTest.java
+++ b/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/design/SendSoapMessageTestDesignerTest.java
@@ -182,6 +182,45 @@ public class SendSoapMessageTestDesignerTest extends AbstractTestNGUnitTest {
     }
     
     @Test
+    public void testMtomSoapAttachment() {
+        MockTestDesigner builder = new MockTestDesigner(applicationContext, context) {
+            @Override
+            public void configure() {
+                soap().client(soapClient)
+                    .send().mtomEnabled(true)
+                    .payload("<TestRequest><data>cid:attachment01</data></TestRequest>")
+                    .attachment(testAttachment);
+            }
+        };
+
+        builder.configure();
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), DelegatingTestAction.class);
+        Assert.assertEquals(((DelegatingTestAction)test.getActions().get(0)).getDelegate().getClass(), SendSoapMessageAction.class);
+        
+        SendSoapMessageAction action = (SendSoapMessageAction) ((DelegatingTestAction)test.getActions().get(0)).getDelegate();
+        Assert.assertEquals(action.getName(), "send");
+        
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageContentBuilder.class);
+
+        StaticMessageContentBuilder messageBuilder = (StaticMessageContentBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "<TestRequest><data>cid:attachment01</data></TestRequest>");
+        Assert.assertEquals(messageBuilder.getMessageHeaders().size(), 0L);
+
+        Assert.assertTrue(action.getMtomEnabled());
+        
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }    
+    
+    @Test
     public void testSoapAttachmentData() {
         MockTestDesigner builder = new MockTestDesigner(applicationContext, context) {
             @Override


### PR DESCRIPTION
Enabled access to mtomEnabled flag for soap send actions for both client
and server through the java dsl (designer).
So far mtom-enabled could only be set when writing a citrus test in XML.

```
soap(action -> action.client(myClient)
     .send().mtomEnabled(true)
     .payload(...)
```