### PR TITLE
Created Gemfile to setup and run Jekyll using bundler

### DIFF
--- a/src/site/Gemfile
+++ b/src/site/Gemfile
@@ -1,0 +1,9 @@
+# A Gemfile to build the Citrus Jekyll documentation
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.4"
+gem "jekyll-feed", "~> 0.9.2"
+gem "jemoji", "~> 0.8.0"
+gem "jekyll-sitemap", "~> 1.1"
+gem "jekyll-mentions", "~> 1.2"
+gem "jekyll-redirect-from", "~> 0.12.1"


### PR DESCRIPTION
When I built the Citrus docs on my machine I had to go through an iteration of failing builds due to missing Jekyll plugins.
Using this Gemfile it is possible to automate this setup and run Jekyll locally using bundler.

In case bundler is not already installed:

    gem install bundler

Jekyll build / serve:

    bundle install
    bundle exec jekyll build
    bundle exec jekyll serve