### PR TITLE
Closes #258

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
@@ -241,7 +241,7 @@ public class TestContext {
         Map<String, T> target = new HashMap<>(map.size());
 
         for (Entry<String, T> entry : map.entrySet()) {
-            String key = entry.getKey();
+            String key = replaceDynamicContentInString(entry.getKey());
             T value = entry.getValue();
 
             if (value instanceof String) {

--- a/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
@@ -237,6 +237,7 @@ public class TestContextTest extends AbstractTestNGUnitTest {
     @Test
     public void testReplaceVariablesInMap() {
         context.getVariables().put("test", "123");
+        context.getVariables().put("value", "test");
         
         Map<String, Object> testMap = new HashMap<>();
         testMap.put("plainText", "Hello TestFramework!");
@@ -257,8 +258,11 @@ public class TestContextTest extends AbstractTestNGUnitTest {
         testMap.put("${value}", "test");
         
         testMap = context.resolveDynamicValuesInMap(testMap);
-        
-        Assert.assertEquals(testMap.get("${value}"), "test");
+
+        // Should be null due to variable substitution
+        Assert.assertEquals(testMap.get("${value}"), null);
+        // Should return "test" after variable substitution
+        Assert.assertEquals(testMap.get("test"), "test");
     }
     
     @Test

--- a/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
@@ -237,8 +237,7 @@ public class TestContextTest extends AbstractTestNGUnitTest {
     @Test
     public void testReplaceVariablesInMap() {
         context.getVariables().put("test", "123");
-        context.getVariables().put("value", "test");
-        
+
         Map<String, Object> testMap = new HashMap<>();
         testMap.put("plainText", "Hello TestFramework!");
         testMap.put("value", "${test}");
@@ -255,14 +254,14 @@ public class TestContextTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(testMap.get("value"), "test");
         
         testMap.clear();
-        testMap.put("${value}", "test");
+        testMap.put("${test}", "value");
         
         testMap = context.resolveDynamicValuesInMap(testMap);
 
         // Should be null due to variable substitution
-        Assert.assertEquals(testMap.get("${value}"), null);
+        Assert.assertEquals(testMap.get("${test}"), null);
         // Should return "test" after variable substitution
-        Assert.assertEquals(testMap.get("test"), "test");
+        Assert.assertEquals(testMap.get("123"), "value");
     }
     
     @Test


### PR DESCRIPTION
Enabled variable substitution for map keys which in turn allows to use Citrus context variable substitution for HTTP header key values.