### PR TITLE
Closes #266

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/config/util/VariableExtractorParserUtil.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/config/util/VariableExtractorParserUtil.java
@@ -16,6 +16,7 @@
 
 package com.consol.citrus.config.util;
 
+import com.consol.citrus.validation.GenericPayloadVariableExtractor;
 import com.consol.citrus.validation.json.JsonPathMessageValidationContext;
 import com.consol.citrus.validation.json.JsonPathVariableExtractor;
 import com.consol.citrus.validation.xml.XpathPayloadVariableExtractor;
@@ -36,7 +37,7 @@ import java.util.Map;
  */
 public class VariableExtractorParserUtil {
 
-    public static void parseMessageElement(List<?> messageElements, Map<String, String> xpathMessages, Map<String, String> jsonMessages) {
+    public static void parseMessageElement(List<?> messageElements, Map<String, String> pathMessages) {
         for (Iterator<?> iter = messageElements.iterator(); iter.hasNext(); ) {
             Element messageValue = (Element) iter.next();
             String pathExpression = messageValue.getAttribute("path");
@@ -46,18 +47,13 @@ public class VariableExtractorParserUtil {
                 pathExpression = messageValue.getAttribute("result-type") + ":" + pathExpression;
             }
 
-            if (JsonPathMessageValidationContext.isJsonPathExpression(pathExpression)) {
-                jsonMessages.put(pathExpression, messageValue.getAttribute("variable"));
-            } else {
-                xpathMessages.put(pathExpression, messageValue.getAttribute("variable"));
-            }
+            pathMessages.put(pathExpression, messageValue.getAttribute("variable"));
         }
     }
 
-    public static void addXpathVariableExtractors(Element element, List<VariableExtractor> variableExtractors, Map<String, String> extractXpath) {
-        XpathPayloadVariableExtractor payloadVariableExtractor = new XpathPayloadVariableExtractor();
-        payloadVariableExtractor.setXpathExpressions(extractXpath);
-
+    public static void addVariableExtractors(Element element, List<VariableExtractor> variableExtractors, Map<String, String> extractFromPath) {
+        GenericPayloadVariableExtractor payloadVariableExtractor = new GenericPayloadVariableExtractor();
+        payloadVariableExtractor.setPathExpressions(extractFromPath);
         Map<String, String> namespaces = new HashMap<>();
         Element messageElement = DomUtils.getChildElementByTagName(element, "message");
         if (messageElement != null) {
@@ -70,13 +66,6 @@ public class VariableExtractorParserUtil {
                 payloadVariableExtractor.setNamespaces(namespaces);
             }
         }
-
-        variableExtractors.add(payloadVariableExtractor);
-    }
-
-    public static void addJsonVariableExtractors(List<VariableExtractor> variableExtractors, Map<String, String> extractJsonPath) {
-        JsonPathVariableExtractor payloadVariableExtractor = new JsonPathVariableExtractor();
-        payloadVariableExtractor.setJsonPathExpressions(extractJsonPath);
 
         variableExtractors.add(payloadVariableExtractor);
     }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/config/util/VariableExtractorParserUtil.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/config/util/VariableExtractorParserUtil.java
@@ -55,15 +55,17 @@ public class VariableExtractorParserUtil {
         GenericPayloadVariableExtractor payloadVariableExtractor = new GenericPayloadVariableExtractor();
         payloadVariableExtractor.setPathExpressions(extractFromPath);
         Map<String, String> namespaces = new HashMap<>();
-        Element messageElement = DomUtils.getChildElementByTagName(element, "message");
-        if (messageElement != null) {
-            List<?> namespaceElements = DomUtils.getChildElementsByTagName(messageElement, "namespace");
-            if (namespaceElements.size() > 0) {
-                for (Iterator<?> iter = namespaceElements.iterator(); iter.hasNext(); ) {
-                    Element namespaceElement = (Element) iter.next();
-                    namespaces.put(namespaceElement.getAttribute("prefix"), namespaceElement.getAttribute("value"));
+        if(element != null) {
+            Element messageElement = DomUtils.getChildElementByTagName(element, "message");
+            if (messageElement != null) {
+                List<?> namespaceElements = DomUtils.getChildElementsByTagName(messageElement, "namespace");
+                if (namespaceElements.size() > 0) {
+                    for (Iterator<?> iter = namespaceElements.iterator(); iter.hasNext(); ) {
+                        Element namespaceElement = (Element) iter.next();
+                        namespaces.put(namespaceElement.getAttribute("prefix"), namespaceElement.getAttribute("value"));
+                    }
+                    payloadVariableExtractor.setNamespaces(namespaces);
                 }
-                payloadVariableExtractor.setNamespaces(namespaces);
             }
         }
 

--- a/modules/citrus-core/src/main/java/com/consol/citrus/config/xml/ReceiveMessageActionParser.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/config/xml/ReceiveMessageActionParser.java
@@ -178,19 +178,14 @@ public class ReceiveMessageActionParser extends AbstractMessageActionParser {
 
         Element extractElement = DomUtils.getChildElementByTagName(element, "extract");
         if (extractElement != null) {
-            Map<String, String> extractXpath = new HashMap<>();
-            Map<String, String> extractJsonPath = new HashMap<>();
+            Map<String, String> extractFromPath = new HashMap<>();
 
             List<Element> messageValueElements = DomUtils.getChildElementsByTagName(extractElement, "message");
             messageValueElements.addAll(DomUtils.getChildElementsByTagName(extractElement, "body"));
-            VariableExtractorParserUtil.parseMessageElement(messageValueElements, extractXpath, extractJsonPath);
+            VariableExtractorParserUtil.parseMessageElement(messageValueElements, extractFromPath);
 
-            if (!CollectionUtils.isEmpty(extractJsonPath)) {
-                VariableExtractorParserUtil.addJsonVariableExtractors(variableExtractors, extractJsonPath);
-            }
-
-            if (!CollectionUtils.isEmpty(extractXpath)) {
-                VariableExtractorParserUtil.addXpathVariableExtractors(element, variableExtractors, extractXpath);
+            if (!CollectionUtils.isEmpty(extractFromPath)) {
+                VariableExtractorParserUtil.addVariableExtractors(element, variableExtractors, extractFromPath);
             }
         }
         return variableExtractors;

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/GenericPayloadVariableExtractor.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/GenericPayloadVariableExtractor.java
@@ -54,8 +54,18 @@ public class GenericPayloadVariableExtractor implements VariableExtractor {
         Map<String, String> xPath = new HashMap<>();
 
         for(Map.Entry<String, String> pathExpression : pathExpressions.entrySet()) {
-            final String path = context.replaceDynamicContentInString(pathExpression.getKey());
-            final String variable = context.replaceDynamicContentInString(pathExpression.getValue());
+            String path = pathExpression.getKey();
+            String variable = pathExpression.getValue();
+            // Try to substitute variable to include XPath / JSONPath expressions stored in variables
+            try {
+                path = context.replaceDynamicContentInString(path);
+                variable = context.replaceDynamicContentInString(variable);
+            } catch (CitrusRuntimeException e) {
+                // Skip invalid variable substitution errors, rethrow others
+                if(!e.getMessage().contains("Unknown variable")) {
+                    throw e;
+                }
+            }
 
             if (JsonPathMessageValidationContext.isJsonPathExpression(path)) {
                 jsonPath.put(path, variable);

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/GenericPayloadVariableExtractor.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/GenericPayloadVariableExtractor.java
@@ -1,0 +1,113 @@
+package com.consol.citrus.validation;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.message.Message;
+import com.consol.citrus.validation.json.JsonPathMessageValidationContext;
+import com.consol.citrus.validation.json.JsonPathVariableExtractor;
+import com.consol.citrus.validation.xml.XpathMessageValidationContext;
+import com.consol.citrus.validation.xml.XpathPayloadVariableExtractor;
+import com.consol.citrus.variable.VariableExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Created by Simon Hofmann on 18.07.17.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Generic extractor implementation which reads messages via JSONPath or XPath
+ *
+ * @author Simon Hofmann
+ * @since 2.7.3
+ */
+public class GenericPayloadVariableExtractor implements VariableExtractor {
+
+    /** Map defines path expressions and target variable names */
+    private Map<String, String> pathExpressions = new HashMap<>();
+
+    private Map<String, String> namespaces = new HashMap<>();
+
+    /** Logger */
+    private static Logger log = LoggerFactory.getLogger(GenericPayloadVariableExtractor.class);
+
+    @Override
+    public void extractVariables(Message message, TestContext context) {
+        if (CollectionUtils.isEmpty(pathExpressions)) {return;}
+
+        if (log.isDebugEnabled()) {
+            log.debug("Reading path elements.");
+        }
+
+        JsonPathVariableExtractor jsonPathVariableExtractor = new JsonPathVariableExtractor();
+        XpathPayloadVariableExtractor xpathPayloadVariableExtractor = new XpathPayloadVariableExtractor();
+
+        if(!this.namespaces.isEmpty()) {
+            xpathPayloadVariableExtractor.setNamespaces(this.namespaces);
+        }
+
+        Map<String, String> jsonPath = new HashMap<>();
+        Map<String, String> xPath = new HashMap<>();
+
+        for(Map.Entry<String, String> pathExpression : pathExpressions.entrySet()) {
+            final String path = context.replaceDynamicContentInString(pathExpression.getKey());
+            final String variable = context.replaceDynamicContentInString(pathExpression.getValue());
+
+            if (JsonPathMessageValidationContext.isJsonPathExpression(path)) {
+                jsonPath.put(path, variable);
+            } else {
+                xPath.put(path, variable);
+            }
+        }
+
+        try {
+            if(!jsonPath.isEmpty()) {
+                jsonPathVariableExtractor.setJsonPathExpressions(jsonPath);
+                jsonPathVariableExtractor.extractVariables(message, context);
+            }
+            if(!xPath.isEmpty()) {
+                xpathPayloadVariableExtractor.setXpathExpressions(xPath);
+                xpathPayloadVariableExtractor.extractVariables(message, context);
+            }
+        } catch (CitrusRuntimeException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Sets the JSONPath / XPath expressions.
+     * @param pathExpressions
+     */
+    public void setPathExpressions(Map<String, String> pathExpressions) {
+        this.pathExpressions = pathExpressions;
+    }
+
+    /**
+     * Gets the JSONPath / XPath expressions.
+     * @return
+     */
+    public Map<String, String> getPathExpressions() {
+        return pathExpressions;
+    }
+
+    /**
+     * Gets the XPath namespaces
+     * @return the namespaces
+     */
+    public Map<String, String> getNamespaces() {
+        return namespaces;
+    }
+
+    /**
+     * Sets the namespaces
+     * @param namespaces the namespaces
+     */
+    public void setNamespaces(Map<String, String> namespaces) {
+        this.namespaces = namespaces;
+    }
+
+}

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/json/JsonPathMessageValidationContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/json/JsonPathMessageValidationContext.java
@@ -50,7 +50,7 @@ public class JsonPathMessageValidationContext implements ValidationContext {
     }
 
     /**
-     * Check wheather give path expression is a JSONPath expression.
+     * Check whether given path expression is a JSONPath expression.
      * @param pathExpression
      * @return
      */

--- a/modules/citrus-core/src/test/java/com/consol/citrus/config/xml/ReceiveMessageActionParserTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/config/xml/ReceiveMessageActionParserTest.java
@@ -19,12 +19,17 @@ package com.consol.citrus.config.xml;
 import com.consol.citrus.actions.ReceiveMessageAction;
 import com.consol.citrus.endpoint.Endpoint;
 import com.consol.citrus.testng.AbstractActionParserTest;
+import com.consol.citrus.validation.GenericPayloadVariableExtractor;
 import com.consol.citrus.validation.builder.PayloadTemplateMessageBuilder;
 import com.consol.citrus.validation.context.DefaultValidationContext;
-import com.consol.citrus.validation.json.*;
+import com.consol.citrus.validation.json.JsonMessageValidationContext;
+import com.consol.citrus.validation.json.JsonPathMessageConstructionInterceptor;
+import com.consol.citrus.validation.json.JsonPathMessageValidationContext;
 import com.consol.citrus.validation.script.GroovyScriptMessageBuilder;
 import com.consol.citrus.validation.script.ScriptValidationContext;
-import com.consol.citrus.validation.xml.*;
+import com.consol.citrus.validation.xml.XmlMessageValidationContext;
+import com.consol.citrus.validation.xml.XpathMessageConstructionInterceptor;
+import com.consol.citrus.validation.xml.XpathMessageValidationContext;
 import com.consol.citrus.variable.MessageHeaderVariableExtractor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -142,14 +147,14 @@ public class ReceiveMessageActionParserTest extends AbstractActionParserTest<Rec
         Assert.assertEquals(action.getVariableExtractors().size(), 2);
         Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
         MessageHeaderVariableExtractor headerVariableExtractor = (MessageHeaderVariableExtractor)action.getVariableExtractors().get(0);
-        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof XpathPayloadVariableExtractor);
-        XpathPayloadVariableExtractor variableExtractor = (XpathPayloadVariableExtractor)action.getVariableExtractors().get(1);
+        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof GenericPayloadVariableExtractor);
+        GenericPayloadVariableExtractor variableExtractor = (GenericPayloadVariableExtractor)action.getVariableExtractors().get(1);
         
         Assert.assertEquals(variableExtractor.getNamespaces().size(), 0L);
         Assert.assertEquals(headerVariableExtractor.getHeaderMappings().size(), 1);
         Assert.assertEquals(headerVariableExtractor.getHeaderMappings().get("operation"), "operation");
-        Assert.assertEquals(variableExtractor.getXpathExpressions().size(), 1);
-        Assert.assertEquals(variableExtractor.getXpathExpressions().get("/TestMessage/text()"), "text");
+        Assert.assertEquals(variableExtractor.getPathExpressions().size(), 1);
+        Assert.assertEquals(variableExtractor.getPathExpressions().get("/TestMessage/text()"), "text");
 
         Assert.assertNotNull(action.getDataDictionary());
 
@@ -321,12 +326,12 @@ public class ReceiveMessageActionParserTest extends AbstractActionParserTest<Rec
         Assert.assertEquals(action.getVariableExtractors().size(), 2);
         Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
         headerVariableExtractor = (MessageHeaderVariableExtractor)action.getVariableExtractors().get(0);
-        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof JsonPathVariableExtractor);
-        JsonPathVariableExtractor jsonVariableExtractor = (JsonPathVariableExtractor)action.getVariableExtractors().get(1);
+        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof GenericPayloadVariableExtractor);
+        GenericPayloadVariableExtractor jsonVariableExtractor = (GenericPayloadVariableExtractor) action.getVariableExtractors().get(1);
 
         Assert.assertEquals(headerVariableExtractor.getHeaderMappings().size(), 1);
         Assert.assertEquals(headerVariableExtractor.getHeaderMappings().get("operation"), "operation");
-        Assert.assertEquals(jsonVariableExtractor.getJsonPathExpressions().size(), 1);
-        Assert.assertEquals(jsonVariableExtractor.getJsonPathExpressions().get("$.message.text"), "text");
+        Assert.assertEquals(jsonVariableExtractor.getPathExpressions().size(), 1);
+        Assert.assertEquals(jsonVariableExtractor.getPathExpressions().get("$.message.text"), "text");
     }
 }

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpReceiveRequestActionParserTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpReceiveRequestActionParserTest.java
@@ -22,10 +22,10 @@ import com.consol.citrus.endpoint.resolver.DynamicEndpointUriResolver;
 import com.consol.citrus.http.message.HttpMessageHeaders;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.testng.AbstractActionParserTest;
+import com.consol.citrus.validation.GenericPayloadVariableExtractor;
 import com.consol.citrus.validation.builder.PayloadTemplateMessageBuilder;
 import com.consol.citrus.validation.context.DefaultValidationContext;
 import com.consol.citrus.validation.json.JsonMessageValidationContext;
-import com.consol.citrus.validation.json.JsonPathVariableExtractor;
 import com.consol.citrus.validation.xml.XmlMessageValidationContext;
 import org.springframework.http.HttpMethod;
 import org.testng.Assert;
@@ -96,8 +96,8 @@ public class HttpReceiveRequestActionParserTest extends AbstractActionParserTest
         Assert.assertNull(action.getEndpointUri());
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1L);
-        Assert.assertEquals(((JsonPathVariableExtractor)action.getVariableExtractors().get(0)).getJsonPathExpressions().size(), 1L);
-        Assert.assertEquals(((JsonPathVariableExtractor)action.getVariableExtractors().get(0)).getJsonPathExpressions().get("$.user.id"), "userId");
+        Assert.assertEquals(((GenericPayloadVariableExtractor)action.getVariableExtractors().get(0)).getPathExpressions().size(), 1L);
+        Assert.assertEquals(((GenericPayloadVariableExtractor)action.getVariableExtractors().get(0)).getPathExpressions().get("$.user.id"), "userId");
 
         action = getNextTestActionFromTest();
         Assert.assertEquals(action.getValidationContexts().size(), 1);

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpReceiveResponseActionParserTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpReceiveResponseActionParserTest.java
@@ -21,6 +21,7 @@ import com.consol.citrus.actions.ReceiveMessageAction;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.message.HttpMessageHeaders;
 import com.consol.citrus.testng.AbstractActionParserTest;
+import com.consol.citrus.validation.GenericPayloadVariableExtractor;
 import com.consol.citrus.validation.builder.PayloadTemplateMessageBuilder;
 import com.consol.citrus.validation.context.DefaultValidationContext;
 import com.consol.citrus.validation.json.JsonMessageValidationContext;
@@ -81,8 +82,8 @@ public class HttpReceiveResponseActionParserTest extends AbstractActionParserTes
         Assert.assertNull(action.getEndpointUri());
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1L);
-        Assert.assertEquals(((JsonPathVariableExtractor)action.getVariableExtractors().get(0)).getJsonPathExpressions().size(), 1L);
-        Assert.assertEquals(((JsonPathVariableExtractor)action.getVariableExtractors().get(0)).getJsonPathExpressions().get("$.user.id"), "userId");
+        Assert.assertEquals(((GenericPayloadVariableExtractor)action.getVariableExtractors().get(0)).getPathExpressions().size(), 1L);
+        Assert.assertEquals(((GenericPayloadVariableExtractor)action.getVariableExtractors().get(0)).getPathExpressions().get("$.user.id"), "userId");
 
         action = getNextTestActionFromTest();
         Assert.assertEquals(action.getValidationContexts().size(), 1);

--- a/modules/citrus-integration/src/it/java/com/consol/citrus/variables/UseXPathVariablesIT.java
+++ b/modules/citrus-integration/src/it/java/com/consol/citrus/variables/UseXPathVariablesIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2006-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.variables;
+
+import com.consol.citrus.annotations.CitrusXmlTest;
+import com.consol.citrus.testng.AbstractTestNGCitrusTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2008
+ */
+public class UseXPathVariablesIT extends AbstractTestNGCitrusTest {
+    @Test
+    @CitrusXmlTest
+    public void UseXPathVariablesIT() {}
+}

--- a/modules/citrus-integration/src/it/resources/com/consol/citrus/variables/UseVariablesIT.xml
+++ b/modules/citrus-integration/src/it/resources/com/consol/citrus/variables/UseVariablesIT.xml
@@ -80,9 +80,9 @@
             <trace-variables>
               <variable name="${id}"/>
               <variable name="${correlationId}"/>
-                      <variable name="${operation}"/>
-                      <variable name="${messageId}"/>
-                      <variable name="${user}"/>
+              <variable name="${operation}"/>
+              <variable name="${messageId}"/>
+              <variable name="${user}"/>
             </trace-variables>
         </actions>
     </testcase>

--- a/modules/citrus-integration/src/it/resources/com/consol/citrus/variables/UseXPathVariablesIT.xml
+++ b/modules/citrus-integration/src/it/resources/com/consol/citrus/variables/UseXPathVariablesIT.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
+    <testcase name="UseXPathVariablesIT">
+        <meta-info>
+            <author>Simon Hofmann</author>
+            <creationdate>2017-07-22</creationdate>
+            <status>FINAL</status>
+            <last-updated-by>Simon Hofmann</last-updated-by>
+            <last-updated-on>2017-07-22T00:00:00</last-updated-on>
+        </meta-info>
+
+        <description>
+            This test shows how to extract variables using XPath expression stored in test variables.
+
+            In this test a Citrus test variable is used to store an XPath expression.
+            This variable is used to extract values from received payload.
+
+            Using Citrus test variables to hold XPath expressions allows to define the XPath expression once and use it
+            in several test cases.
+        </description>
+
+        <variables>
+            <variable name="correlationId" value="citrus:randomNumber(10)"></variable>
+            <variable name="messageId" value="citrus:randomNumber(10)"></variable>
+            <variable name="extractFromPath" value="//:HelloResponse/:User"></variable>
+        </variables>
+
+        <actions>
+            <send endpoint="helloRequestSender">
+                <description>
+                    Send asynchronous hello request: TestFramework -> HelloService
+                </description>
+                <message>
+                    <data>
+                        <![CDATA[
+                           <HelloRequest xmlns="http://www.consol.de/schemas/samples/sayHello.xsd">
+                               <MessageId>${messageId}</MessageId>
+                               <CorrelationId>${correlationId}</CorrelationId>
+                               <User>Christoph</User>
+                               <Text>Hello TestFramework</Text>
+                           </HelloRequest>                              
+                        ]]>
+                    </data>
+                </message>
+                <header>
+                    <element name="Operation" value="sayHello"/>
+                    <element name="CorrelationId" value="${correlationId}"/>
+                </header>
+            </send>
+
+            <receive endpoint="helloResponseReceiver">
+                <message>
+                    <validate path="HelloResponse.CorrelationId" value="${correlationId}"/>
+                </message>
+                <extract>
+                    <header name="Operation" variable="${operation}"/>
+                    <header name="CorrelationId" variable="${id}"/>
+                    <message path="${extractFromPath}" variable="${user}"/>
+                </extract>
+            </receive>
+
+            <echo>
+                <message>${operation}</message>
+            </echo>
+
+            <trace-variables>
+                <variable name="${id}"/>
+                <variable name="${correlationId}"/>
+                <variable name="${operation}"/>
+                <variable name="${messageId}"/>
+                <variable name="${user}"/>
+            </trace-variables>
+        </actions>
+    </testcase>
+</spring:beans>

--- a/modules/citrus-zookeeper/src/main/java/com/consol/citrus/zookeeper/config/xml/ZooExecuteActionParser.java
+++ b/modules/citrus-zookeeper/src/main/java/com/consol/citrus/zookeeper/config/xml/ZooExecuteActionParser.java
@@ -111,9 +111,9 @@ public class ZooExecuteActionParser implements BeanDefinitionParser {
         List<VariableExtractor> variableExtractors = new ArrayList<>();
         Map<String, String> extractJsonPath = new HashMap<>();
         List<?> messageValueElements = DomUtils.getChildElementsByTagName(extractElement, "message");
-        VariableExtractorParserUtil.parseMessageElement(messageValueElements, null, extractJsonPath);
+        VariableExtractorParserUtil.parseMessageElement(messageValueElements, extractJsonPath);
         if (!CollectionUtils.isEmpty(extractJsonPath)) {
-            VariableExtractorParserUtil.addJsonVariableExtractors(variableExtractors, extractJsonPath);
+            VariableExtractorParserUtil.addVariableExtractors(extractElement, variableExtractors, extractJsonPath);
         }
         return variableExtractors;
     }


### PR DESCRIPTION
This PR implements a generic variable extractor which substitutes Citrus test variables at runtime and uses the correct extractor.
This allows to use XPath / JSONPath expression stored in Citrus variables for variable extraction.