### PR TITLE
298 test ng dataprovider parameters cannot be used in variables block

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
@@ -213,6 +213,26 @@ public class TestContext {
 
         variables.put(VariableUtils.cutOffVariablesPrefix(variableName), value);
     }
+
+    /**
+     * Add variables to context.
+     * @param variableNames the variable names to set
+     * @param variableValues the variable values to set
+     */
+    public void addVariables(String[] variableNames, Object[] variableValues) {
+        if (variableNames.length != variableValues.length) {
+            throw new CitrusRuntimeException(String.format(
+                    "Invalid test parameter usage - received '%s' parameters with '%s' values",
+                    variableNames.length,
+                    variableValues.length));
+        }
+
+        for (int i = 0; i < variableNames.length; i++) {
+            if (variableValues[i] != null) {
+                setVariable(variableNames[i], variableValues[i]);
+            }
+        }
+    }
     
     /**
      * Add several new variables to test context. Existing variables will be 

--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
@@ -222,7 +222,7 @@ public class TestContext {
     public void addVariables(String[] variableNames, Object[] variableValues) {
         if (variableNames.length != variableValues.length) {
             throw new CitrusRuntimeException(String.format(
-                    "Invalid test parameter usage - received '%s' parameters with '%s' values",
+                    "Invalid context variable usage - received '%s' variables with '%s' values",
                     variableNames.length,
                     variableValues.length));
         }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/testng/AbstractTestNGCitrusTest.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/testng/AbstractTestNGCitrusTest.java
@@ -156,6 +156,7 @@ public abstract class AbstractTestNGCitrusTest extends AbstractTestNGSpringConte
             if (parameters != null) {
                 dataProviderParams = parameters[invocationCount % parameters.length];
                 injectTestParameters(method, testCase, dataProviderParams);
+                injectContextVariables(method, context, dataProviderParams);
             }
         }
 
@@ -181,6 +182,10 @@ public abstract class AbstractTestNGCitrusTest extends AbstractTestNGSpringConte
         }
 
         return values;
+    }
+
+    private void injectContextVariables(Method method, TestContext context, Object[] dataProviderParams) {
+        context.addVariables(getParameterNames(method), dataProviderParams);
     }
 
     /**

--- a/modules/citrus-core/src/test/java/com/consol/citrus/context/DataProviderAvailableInVariableBlockTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/context/DataProviderAvailableInVariableBlockTest.java
@@ -1,0 +1,24 @@
+package com.consol.citrus.context;
+
+import com.consol.citrus.annotations.CitrusXmlTest;
+import com.consol.citrus.testng.AbstractTestNGCitrusTest;
+import com.consol.citrus.testng.CitrusParameters;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class DataProviderAvailableInVariableBlockTest extends AbstractTestNGCitrusTest {
+
+    @DataProvider(name = "someDataProvider")
+    public Object[][] someDataProvider() {
+        return new Object[][]{
+                new Object[]{"some_value"},
+        };
+    }
+
+    @Test(dataProvider = "someDataProvider")
+    @CitrusParameters({"someVariable"})
+    @CitrusXmlTest(name = "DataProviderAvailableInVariableBlockTest")
+    @SuppressWarnings("unused")
+    public void test(String someVariable) {
+    }
+}

--- a/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/context/TestContextTest.java
@@ -233,6 +233,35 @@ public class TestContextTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(context.getVariable("test1"), "123");
         Assert.assertEquals(context.getVariable("test2"), "");
     }
+
+    @Test
+    public void testAddVariablesFromArrays() {
+
+        //GIVEN
+        String[] variableNames = {"variable1", "${variable2}"};
+        Object[] variableValues= {"value1", ""};
+
+        //WHEN
+        context.addVariables(variableNames, variableValues);
+
+        //THEN
+        Assert.assertEquals(context.getVariable("variable1"), "value1");
+        Assert.assertEquals(context.getVariable("variable2"), "");
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class)
+    public void testAddVariablesThrowsExceptionIfArraysHaveDifferentSize() {
+
+        //GIVEN
+        String[] variableNames = {"variable1", "variable2"};
+        Object[] variableValues= {"value1"};
+
+        //WHEN
+        context.addVariables(variableNames, variableValues);
+
+        //THEN
+        //Exception is thrown
+    }
     
     @Test
     public void testReplaceVariablesInMap() {

--- a/modules/citrus-core/src/test/resources/com/consol/citrus/context/DataProviderAvailableInVariableBlockTest.xml
+++ b/modules/citrus-core/src/test/resources/com/consol/citrus/context/DataProviderAvailableInVariableBlockTest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                                  http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
+    <testcase name="DataProviderAvailableInVariableBlockTest">
+        <variables>
+            <!-- Makes sure that this DataProvider bound variable is available -->
+            <variable name="otherVariable" value="${someVariable}"/>
+        </variables>
+
+        <actions>
+            <echo>
+                <message>${otherVariable}</message>
+            </echo>
+        </actions>
+    </testcase>
+</spring:beans>


### PR DESCRIPTION
Hi!

I solved #298 by adding the TestNG DataProvider values as variables to the TestContext, as proposed in the Issue by @gucce.
In addition, I added the test case provided in the Issue as an automated test so that this problem will never occur again. I'm not sure whether I met the your expectations concerning the project structure, test coverage and code style.
I'm looking forward to your feedback.

BR,
Sven