### PR TITLE
(#298) Fixed CitrusXmlTest reference

### DIFF
--- a/modules/citrus-core/src/test/java/com/consol/citrus/integration/parameter/TestParameterIT.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/integration/parameter/TestParameterIT.java
@@ -33,7 +33,7 @@ public class TestParameterIT extends AbstractTestNGCitrusTest {
 
     @Test(dataProvider = "someDataProvider")
     @CitrusParameters({"someVariable"})
-    @CitrusXmlTest(name = "DataProviderAvailableInVariableBlockTest")
+    @CitrusXmlTest(name = "TestParameterIT")
     @SuppressWarnings("unused")
     public void test(String someVariable) {
     }


### PR DESCRIPTION
Hi!

As I reviewed your changes, I found that the CitrusXmlTest reference was not changed after renaming the xml file. Therefore the test failed.