### PR TITLE
Update http request variable in template

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessage.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessage.java
@@ -50,6 +50,7 @@ public class HttpMessage extends DefaultMessage {
      */
     public HttpMessage(Message message) {
         super(message);
+        setCookies(message);
     }
 
     /**
@@ -67,6 +68,16 @@ public class HttpMessage extends DefaultMessage {
      */
     public HttpMessage(Object payload, Map<String, Object> headers) {
         super(payload, headers);
+    }
+
+    /**
+     * Sets the cookies extracted from the given message as far as it is a HttpMessage
+     * @param message the message to extract the cookies from
+     */
+    private void setCookies(Message message) {
+        if(message instanceof HttpMessage){
+            this.cookies =((HttpMessage) message).getCookies();
+        }
     }
 
     /**

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
@@ -52,15 +52,10 @@ public class HttpMessageContentBuilder extends AbstractMessageContentBuilder {
 
     @Override
     public Message buildMessageContent(TestContext context, String messageType, MessageDirection direction) {
-        //TODO: Fix state problem
-        //Because the message is manipulated through the message execution and stateful,
-        //the variable placeholder in the headers are replaced by the concrete values.
-        //This leads to the problem, that a second execution of the request will not obtain the new values,
-        //because the placeholders have already been replaced.
-        //Working on a copy is also not possible, because the state of the message is required for the HttpCookiesIT
-//        HttpMessage messageToBuild = new HttpMessage(message);
-        HttpMessage messageToBuild = message;
-        delegate.setMessageHeaders(message.getHeaders());
+        //Copy the initial message, so that it is not manipulated during the test.
+        HttpMessage messageToBuild = new HttpMessage(message);
+
+        delegate.setMessageHeaders(messageToBuild.getHeaders());
 
         messageToBuild.setName(delegate.getMessageName());
 
@@ -73,7 +68,6 @@ public class HttpMessageContentBuilder extends AbstractMessageContentBuilder {
             }
         }
         messageToBuild.setPayload(delegateMessage.getPayload());
-        
         for (Cookie cookie: messageToBuild.getCookies()) {
             if (cookie.getValue() != null) {
                 cookie.setValue(context.replaceDynamicContentInString(cookie.getValue()));

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
@@ -77,10 +77,6 @@ public class HttpMessageContentBuilder extends AbstractMessageContentBuilder {
                 cookie.setComment(context.replaceDynamicContentInString(cookie.getComment()));
             }
 
-            if (cookie.getComment() != null) {
-                cookie.setComment(context.replaceDynamicContentInString(cookie.getComment()));
-            }
-
             if (cookie.getPath() != null) {
                 cookie.setPath(context.replaceDynamicContentInString(cookie.getPath()));
             }

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/integration/HttpClientTemplateIT.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/integration/HttpClientTemplateIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2006-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.http.integration;
+
+import com.consol.citrus.annotations.CitrusXmlTest;
+import com.consol.citrus.testng.AbstractTestNGCitrusTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Test
+public class HttpClientTemplateIT extends AbstractTestNGCitrusTest {
+
+    @CitrusXmlTest(name = "HttpClientTemplateIT")
+    public void testHttpTemplateClient() {}
+}

--- a/modules/citrus-http/src/test/resources/com/consol/citrus/http/integration/HttpClientTemplateIT.xml
+++ b/modules/citrus-http/src/test/resources/com/consol/citrus/http/integration/HttpClientTemplateIT.xml
@@ -1,0 +1,55 @@
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:http="http://www.citrusframework.org/schema/http/testcase"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                                  http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd
+                                  http://www.citrusframework.org/schema/http/testcase http://www.citrusframework.org/schema/http/testcase/citrus-http-testcase.xsd">
+
+
+    <template name="httpClient">
+        <echo>
+            <message>ID = ${id}</message>
+        </echo>
+        <http:send-request client="echoHttpClient">
+            <http:GET path="/idTest?id=${id}" />
+        </http:send-request>
+    </template>
+
+
+    <testcase name="HttpClientTemplateIT">
+    <meta-info>
+        <author>Sven Hettwer</author>
+        <creationdate>2017-12-07</creationdate>
+        <status>FINAL</status>
+        <last-updated-by>Sven Hettwer</last-updated-by>
+        <last-updated-on>2017-12-07T00:00:00</last-updated-on>
+    </meta-info>
+
+    <description>This tests sends to HTTP messages to a server from within a template</description>
+
+        <actions>
+            <call-template name="httpClient">
+                <parameter name="id" value="123" />
+            </call-template>
+
+            <http:receive-request server="echoHttpServer">
+                <http:GET path="/echo/idTest">
+                    <http:param name="id" value="123"/>
+                </http:GET>
+            </http:receive-request>
+
+            <call-template name="httpClient">
+                <parameter name="id" value="456" />
+            </call-template>
+
+            <http:receive-request server="echoHttpServer">
+                <http:GET path="/echo/idTest">
+                    <http:param name="id" value="456"/>
+                </http:GET>
+            </http:receive-request>
+
+        </actions>
+
+    </testcase>
+</spring:beans>


### PR DESCRIPTION
Hi!

This is my attempt to solve #271. 
I found out, that the HttpMessageContentBuilder.buildMessageContent method worked on the initial request defined in the template and therefore replaced all variable placeholders with the concrete values. This led to the observed behavior. 

Now the buildMessageContent method works on a copy of the initial HttpMessage so that it is idempotent concerning the provided message. To create the copy, I had to adapt the copy Constructor of the HttpMessage, because the cookies where not copied if the provided Message was a HttpMessage instance.

In addition I applied some structural changes to the HttpMessageContentBuilder by extracting several methods. The non functional changes have been applied after the actual problem has been solved. So you may want to review commit by commit. 

As always: I'm looking forward to your feedback. ;-)

BR,
Sven