### PR TITLE
Fixed link to the consulting info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Consulting
 ---------
 
 Just in case you need professional support for Citrus have a look at
-'http://www.citrusframework.org/contact.html'.
+'http://www.citrusframework.org/docs/consulting/'.
 Contact user@citrusframework.org directly for any request or questions
 (or use the contact form at 'http://www.consol.com/contact/')
 


### PR DESCRIPTION
Hi @christophd.

I found out that ```http://www.citrusframework.org/contact.html``` results in a 404. Therefore I exchanged the URL and hope that I've chosen the correct one. ;-)

BR,
Sven