### PR TITLE
#369 Default responses for JDBC requests

### DIFF
--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/annotation/JdbcServerConfig.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/annotation/JdbcServerConfig.java
@@ -70,6 +70,12 @@ public @interface JdbcServerConfig {
     boolean autoCreateStatement() default true;
 
     /**
+     * Auto reply check connetion queries.
+     * @return
+     */
+    boolean autoReplyConnectionValidationQueries() default false;
+
+    /**
      * Message correlator.
      * @return
      */

--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/annotation/JdbcServerConfigParser.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/annotation/JdbcServerConfigParser.java
@@ -64,6 +64,7 @@ public class JdbcServerConfigParser extends AbstractAnnotationConfigParser<JdbcS
         builder.autoConnect(annotation.autoConnect());
         builder.autoCreateStatement(annotation.autoCreateStatement());
         builder.autoTransactionHandling(annotation.autoTransactionHandling());
+        builder.autoReplyConnectionValidationQueries(annotation.autoReplyConnectionValidationQueries());
 
         if (StringUtils.hasText(annotation.correlator())) {
             builder.correlator(getReferenceResolver().resolve(annotation.correlator(), MessageCorrelator.class));

--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParser.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParser.java
@@ -58,6 +58,7 @@ public class JdbcEndpointConfigurationParser {
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-connect"), "autoConnect");
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-create-statement"), "autoCreateStatement");
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-transaction-handling"), "autoTransactionHandling");
+        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-reply-connection-validation-queries"), "autoReplyConnectionValidationQueries");
 
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("polling-interval"), "pollingInterval");
         BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("message-correlator"), "correlator");

--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/ConnectionValidationQueryPatternMatcher.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/ConnectionValidationQueryPatternMatcher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.jdbc.server;
+
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Georgi Todorov
+ * @since 2.7.5
+ */
+public class ConnectionValidationQueryPatternMatcher {
+
+    protected static final String CONNECTION_VALIDATION_QUERIES_PROPERTY = "citrus.jdbc.connection.validaiton.queries";
+
+    /**
+     * ';' separated list of validation queries for different databases
+     */
+    private final String validationQueryPatterns =
+                    "SELECT \\w*;" + //e.g. H2, MySQL, PostgreSQL, SQLite, Microsoft SQL Server
+                    "SELECT.*FROM DUAL;" + // Oracle
+                    "SELECT.*FROM SYSIBM.SYSDUMMY1;"; // DB2
+
+    private Pattern queryValidationPattern;
+
+    public ConnectionValidationQueryPatternMatcher() {
+        String connectionValidationQueries = System.getProperty(CONNECTION_VALIDATION_QUERIES_PROPERTY, validationQueryPatterns);
+        List<String> validationQueryPatterns = Arrays.stream(connectionValidationQueries.split(";"))
+                .map(String::trim)
+                .filter(validationQuery -> !StringUtils.isEmpty(validationQuery))
+                .map(validationQueryPattern -> "(?i)\\A" + validationQueryPattern + "\\Z")
+                .collect(Collectors.toList());
+        queryValidationPattern = Pattern.compile(String.join("|", validationQueryPatterns));
+    }
+
+    public boolean match(String sqlQuery) {
+        return queryValidationPattern.matcher(sqlQuery).find();
+    }
+
+}

--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/JdbcEndpointConfiguration.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/JdbcEndpointConfiguration.java
@@ -43,6 +43,9 @@ public class JdbcEndpointConfiguration extends AbstractPollableEndpointConfigura
     /** Auto accept transaction operations  */
     private boolean autoTransactionHandling = true;
 
+    /** Auto reply connection validation queries sent by the jdbc clients at the beginning of the communication*/
+    private boolean autoReplyConnectionValidationQueries = false;
+
     /** Marshaller converts from XML to Jdbc model objects */
     private JdbcMarshaller marshaller = new JdbcMarshaller();
 
@@ -94,6 +97,24 @@ public class JdbcEndpointConfiguration extends AbstractPollableEndpointConfigura
      */
     public void setAutoCreateStatement(boolean autoCreateStatement) {
         this.autoCreateStatement = autoCreateStatement;
+    }
+
+    /**
+     * Gets the autoReplyConnectionValidationQueries.
+     *
+     * @return
+     */
+    public boolean isAutoReplyConnectionValidationQueries() {
+        return autoReplyConnectionValidationQueries;
+    }
+
+    /**
+     * Sets the autoReplyConnectionValidationQueries
+     *
+     * @param autoReplyConnectionValidationQueries
+     */
+    public void setAutoReplyConnectionValidationQueries(boolean autoReplyConnectionValidationQueries) {
+        this.autoReplyConnectionValidationQueries = autoReplyConnectionValidationQueries;
     }
 
     @Override

--- a/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/JdbcServerBuilder.java
+++ b/modules/citrus-jdbc/src/main/java/com/consol/citrus/jdbc/server/JdbcServerBuilder.java
@@ -95,6 +95,16 @@ public class JdbcServerBuilder extends AbstractEndpointBuilder<JdbcServer> {
     }
 
     /**
+     * Sets the autoReplyConnectionValidationQueries property.
+     * @param autoReplyConnectionValidationQueries
+     * @return
+     */
+    public JdbcServerBuilder autoReplyConnectionValidationQueries(boolean autoReplyConnectionValidationQueries) {
+        endpoint.getEndpointConfiguration().setAutoReplyConnectionValidationQueries(autoReplyConnectionValidationQueries);
+        return this;
+    }
+
+    /**
      * Sets the message correlator.
      * @param correlator
      * @return

--- a/modules/citrus-jdbc/src/test/java/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParserTest.java
+++ b/modules/citrus-jdbc/src/test/java/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParserTest.java
@@ -47,9 +47,6 @@ public class JdbcEndpointConfigurationParserTest extends AbstractBeanDefinitionP
 
     @Test
     public void testAnnotations(){
-
-
-
         assertEquals(
                 testServer.getEndpointConfiguration().getServerConfiguration().getHost(),
                 "foo.bar.test.io");
@@ -92,5 +89,8 @@ public class JdbcEndpointConfigurationParserTest extends AbstractBeanDefinitionP
         assertEquals(
                 testServer.getEndpointConfiguration().isAutoTransactionHandling(),
                 false);
+        assertEquals(
+                testServer.getEndpointConfiguration().isAutoReplyConnectionValidationQueries(),
+                true);
     }
 }

--- a/modules/citrus-jdbc/src/test/java/com/consol/citrus/jdbc/server/ConnectionValidationQueryPatternMatcherTest.java
+++ b/modules/citrus-jdbc/src/test/java/com/consol/citrus/jdbc/server/ConnectionValidationQueryPatternMatcherTest.java
@@ -1,0 +1,47 @@
+package com.consol.citrus.jdbc.server;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class ConnectionValidationQueryPatternMatcherTest {
+
+    @DataProvider
+    public Object[][] matchDP() {
+        return new Object[][] {
+                {"Select 1", true},
+                {"Select 1 from", false},
+                {"SELECT USER", true},
+                {"SELECT USER from DUAL", true},
+                {"SELECT 1 from DUAL", true},
+                {"SELECT USER FROM SYSIBM.SYSDUMMY1", true},
+                {"SELECT 1 FROM SYSIBM.SYSDUMMY1", true},
+                {"SELECT 1 FROM SYSIBM.SYSDUMMY1 where", false},
+        };
+    }
+
+    @Test(dataProvider = "matchDP")
+    public void match(String query, boolean isMatching) {
+        ConnectionValidationQueryPatternMatcher matcher = new ConnectionValidationQueryPatternMatcher();
+        assertEquals(matcher.match(query), isMatching);
+    }
+
+    @DataProvider
+    public Object[][] matchUsingSystemPropertyDP() {
+        return new Object[][] {
+                {"Select 1", true},
+                {"Select 1 from", false},
+                {"SELECT USER", false},
+                {"SELECT 1", true},
+        };
+    }
+
+    @Test(dataProvider = "matchUsingSystemPropertyDP")
+    public void matchUsingSystemProperty(String query, boolean isMatching) {
+        System.setProperty(ConnectionValidationQueryPatternMatcher.CONNECTION_VALIDATION_QUERIES_PROPERTY, "select 1;;");
+        ConnectionValidationQueryPatternMatcher matcher = new ConnectionValidationQueryPatternMatcher();
+        assertEquals(matcher.match(query), isMatching);
+    }
+
+}

--- a/modules/citrus-jdbc/src/test/resources/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParserTest-context.xml
+++ b/modules/citrus-jdbc/src/test/resources/com/consol/citrus/jdbc/config/xml/JdbcEndpointConfigurationParserTest-context.xml
@@ -31,6 +31,7 @@
                       timeout="10"
                       auto-connect="false"
                       auto-create-statement="false"
+                      auto-reply-connection-validation-queries="true"
                       polling-interval="0"
                       auto-start="true"
                       actor="testActor"

--- a/modules/citrus-model/model-jdbc/src/main/resources/com/consol/citrus/schema/citrus-jdbc-config-2.7.5.xsd
+++ b/modules/citrus-model/model-jdbc/src/main/resources/com/consol/citrus/schema/citrus-jdbc-config-2.7.5.xsd
@@ -32,6 +32,7 @@
       <xs:attribute name="database-name" type="xs:string" use="required"/>
       <xs:attribute name="auto-connect" type="xs:boolean"/>
       <xs:attribute name="auto-create-statement" type="xs:boolean"/>
+      <xs:attribute name="auto-reply-connection-validation-queries" type="xs:boolean"/>
       <xs:attribute name="auto-start" type="xs:boolean"/>
       <xs:attribute name="max-connections" type="xs:string"/>
       <xs:attribute name="timeout" type="xs:string"/>

--- a/modules/citrus-model/model-jdbc/src/main/resources/com/consol/citrus/schema/citrus-jdbc-config.xsd
+++ b/modules/citrus-model/model-jdbc/src/main/resources/com/consol/citrus/schema/citrus-jdbc-config.xsd
@@ -32,6 +32,7 @@
       <xs:attribute name="database-name" type="xs:string" use="required"/>
       <xs:attribute name="auto-connect" type="xs:boolean"/>
       <xs:attribute name="auto-create-statement" type="xs:boolean"/>
+      <xs:attribute name="auto-reply-connection-validation-queries" type="xs:boolean"/>
       <xs:attribute name="auto-start" type="xs:boolean"/>
       <xs:attribute name="max-connections" type="xs:string"/>
       <xs:attribute name="timeout" type="xs:string"/>

--- a/src/manual/jdbc.adoc
+++ b/src/manual/jdbc.adoc
@@ -313,6 +313,11 @@ This includes `createStatement`, `createPreparedStatement`, `createCallableState
 | Determines whether the server should automatically accept transaction related messages or validate them.
 This includes `startTransaction`, `commitTransaction` and `rollbackTransaction`.
 
+| auto reply connection validation queries
+| No
+| false
+| Determines whether the server should automatically send a positive answer for connection validation queries sent by the jdbc client, e.g. 'SELECT USER FROM DUAL'. To override the currently defined validation queries just set `citrus.jdbc.connection.validaiton.queries property within the citrus-application.properties. The property is`expected to be a ';'-separated list of queries. Every query can be specified as a regular expression, e.g. 'SELECT.*FROM DUAL;SELECT \\w*;'.
+
 | host
 | Yes
 |


### PR DESCRIPTION
- new configuration property 'auto-reply-connection-validation-queries' on jdbc-server introduced
- in case the flag 'auto-reply-connection-validation-queries' is set to true, certain queries are intercepted in the JdbcEndpointAdapterController and are automatically answered by Citrus with a success and an empty data set.
- a new citrus property 'citrus.jdbc.connection.validaiton.queries' introduced. It can be used to provide a list of queries, which has to be automatically answered by Citrus